### PR TITLE
Follow-up to  #8 to include actual ability to include unpublished objects

### DIFF
--- a/src/GraphQL/Query/QueryType.php
+++ b/src/GraphQL/Query/QueryType.php
@@ -129,7 +129,7 @@ class QueryType extends ObjectType
                     'after' => ['type' => Type::int()],
                     'sortBy' => ['type' => Type::string()],
                     'sortOrder' => ['type' => Type::string()],
-                    'filter' => ['type' => Type::string()]
+                    'filter' => ['type' => Type::string()],
                     'published' => ['type' => Type::boolean()],
                 ],
                 'type' => $listingType,

--- a/src/GraphQL/Query/QueryType.php
+++ b/src/GraphQL/Query/QueryType.php
@@ -130,6 +130,7 @@ class QueryType extends ObjectType
                     'sortBy' => ['type' => Type::string()],
                     'sortOrder' => ['type' => Type::string()],
                     'filter' => ['type' => Type::string()]
+                    'published' => ['type' => Type::boolean()],
                 ],
                 'type' => $listingType,
                 'resolve' => [$resolver, "resolveListing"]

--- a/src/GraphQL/Resolver/QueryType.php
+++ b/src/GraphQL/Resolver/QueryType.php
@@ -225,6 +225,11 @@ class QueryType
             $objectList->setOrder($order);
         }
 
+        // Include unpublished
+        if ($args['published'] === false) {
+            $objectList->setUnpublished(true);
+        }
+
         /** @var $configuration Configuration */
         $configuration = $context['configuration'];
         $sqlListCondition = $configuration->getSqlObjectCondition();


### PR DESCRIPTION
While the previous PR only added the field as a return value (which only ever returned `true`) this allows us to get the publication status like this to include both published and unpublished objects:
```
  {
  getProductListing(published: false) {
    edges {
      node {
        id
        name
        sku
        published
...
```