### PR TITLE
Prevents a fatal error when no mutations are configured

### DIFF
--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -926,6 +926,9 @@ class MutationType extends ObjectType
         $this->buildDeleteAssetMutation($config, $context);
         $this->buildDeleteFolderMutation("asset", $config, $context);
         $this->buildDeleteFolderMutation("object", $config, $context);
-        ksort($config["fields"]);
+
+        if (isset($config["fields"]) && count($config["fields"]) > 1) {
+            ksort($config["fields"]);
+        }
     }
 }


### PR DESCRIPTION
Also: Will not attempt to sort if there is only one mutation, see #43