### PR TITLE
Renames 'childs' to 'children'

### DIFF
--- a/src/GraphQL/InputProcessor/Base.php
+++ b/src/GraphQL/InputProcessor/Base.php
@@ -72,7 +72,7 @@ class Base
      */
     public function getParentProcessor($nodeDef, ClassDefinition $class) {
         $nodeDefAttributes = $nodeDef["attributes"];
-        $children = $nodeDefAttributes["childs"];
+        $children = $nodeDefAttributes['children'];
         if (!$children) {
             return null;
         }

--- a/src/GraphQL/InputProcessor/Base.php
+++ b/src/GraphQL/InputProcessor/Base.php
@@ -72,7 +72,7 @@ class Base
      */
     public function getParentProcessor($nodeDef, ClassDefinition $class) {
         $nodeDefAttributes = $nodeDef["attributes"];
-        $children = $nodeDefAttributes['children'];
+        $children = $nodeDefAttributes['childs'];
         if (!$children) {
             return null;
         }

--- a/src/GraphQL/InputProcessor/IfEmptyOperator.php
+++ b/src/GraphQL/InputProcessor/IfEmptyOperator.php
@@ -39,7 +39,7 @@ class IfEmptyOperator extends BaseOperator
      * @param $context
      * @param ResolveInfo $info
      * @return void|null
-     * @throws \Exception
+     * @throws \Exception|\UnexpectedValueException
      */
     public function process(Concrete $object, $newValue, $args, $context, ResolveInfo $info)
     {
@@ -47,19 +47,19 @@ class IfEmptyOperator extends BaseOperator
 
         $nodeDef = $this->nodeDef;
         $nodeDefAttributes = $nodeDef["attributes"];
-        $children = $nodeDefAttributes["childs"];
+        $children = $nodeDefAttributes['children'];
         if (!$children) {
             return null;
         }
 
-        if (count($children) != 1) {
-            throw new \Exception("only one child allowed");
+        if (count($children) !== 1) {
+            throw new \UnexpectedValueException("Only one child allowed");
         }
 
         $firstChild = $children[0];
 
-        if ($firstChild["isOperator"]) {
-            throw new \Exception("not allowed");
+        if ($firstChild['isOperator']) {
+            throw new \Exception("Not allowed");
         } else {
 
             $key = $firstChild["attributes"]["attribute"];

--- a/src/GraphQL/InputProcessor/IfEmptyOperator.php
+++ b/src/GraphQL/InputProcessor/IfEmptyOperator.php
@@ -47,7 +47,7 @@ class IfEmptyOperator extends BaseOperator
 
         $nodeDef = $this->nodeDef;
         $nodeDefAttributes = $nodeDef["attributes"];
-        $children = $nodeDefAttributes['children'];
+        $children = $nodeDefAttributes['childs'];
         if (!$children) {
             return null;
         }

--- a/src/GraphQL/MutationOperatorConfigGenerator/Base.php
+++ b/src/GraphQL/MutationOperatorConfigGenerator/Base.php
@@ -47,7 +47,7 @@ abstract class Base
     public function resolveInputTypeFromNodeDef($nodeDef, ClassDefinition $class)
     {
         $nodeDefAttributes = $nodeDef["attributes"];
-        $children = $nodeDefAttributes["childs"];
+        $children = $nodeDefAttributes['children'];
 
         $firstChild = $children[0];
         $firstChildAttributes = $firstChild["attributes"];

--- a/src/GraphQL/Query/Operator/AbstractOperator.php
+++ b/src/GraphQL/Query/Operator/AbstractOperator.php
@@ -38,21 +38,21 @@ abstract class AbstractOperator implements OperatorInterface
     /**
      * @var ConfigElementInterface[]
      */
-    protected $childs;
+    protected $children;
 
     public function __construct(array $config = [], $context = null)
     {
         $this->label = $config['label'];
-        $this->childs = $config['childs'];
+        $this->children = $config['children'];
         $this->context = $context;
     }
 
     /**
      * @return ConfigElementInterface[]
      */
-    public function getChilds()
+    public function getChildren()
     {
-        return $this->childs;
+        return $this->children;
     }
 
     /**

--- a/src/GraphQL/Query/Operator/Alias.php
+++ b/src/GraphQL/Query/Operator/Alias.php
@@ -27,12 +27,13 @@ class Alias extends AbstractOperator
         $result = new \stdClass();
         $result->label = $this->label;
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
 
-        if (!$childs) {
+        if (!$children) {
             return $result;
         } else {
-            $c = $childs[0];
+            $c = $children[0];
 
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 

--- a/src/GraphQL/Query/Operator/Concatenator.php
+++ b/src/GraphQL/Query/Operator/Concatenator.php
@@ -43,10 +43,11 @@ class Concatenator extends AbstractOperator
             $hasValue = false;
         }
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
         $valueArray = [];
 
-        foreach ($childs as $c) {
+        foreach ($children as $c) {
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 
             $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);

--- a/src/GraphQL/Query/Operator/DateFormatter.php
+++ b/src/GraphQL/Query/Operator/DateFormatter.php
@@ -40,12 +40,13 @@ class DateFormatter extends AbstractOperator
         $result->label = $this->label;
         $result->value = null;
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
 
-        if (!$childs) {
+        if (!$children) {
             return $result;
         } else {
-            $c = $childs[0];
+            $c = $children[0];
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 
             $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);

--- a/src/GraphQL/Query/Operator/ElementCounter.php
+++ b/src/GraphQL/Query/Operator/ElementCounter.php
@@ -35,10 +35,11 @@ class ElementCounter extends AbstractOperator
         $result = new \stdClass();
         $result->label = $this->label;
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
         $count = 0;
 
-        foreach ($childs as $c) {
+        foreach ($children as $c) {
 
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 

--- a/src/GraphQL/Query/Operator/Merge.php
+++ b/src/GraphQL/Query/Operator/Merge.php
@@ -37,10 +37,12 @@ class Merge extends AbstractOperator
         $result->label = $this->label;
         $result->isArrayType = true;
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
+
         $resultItems = [];
 
-        foreach ($childs as $c) {
+        foreach ($children as $c) {
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 
             $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);

--- a/src/GraphQL/Query/Operator/Substring.php
+++ b/src/GraphQL/Query/Operator/Substring.php
@@ -41,12 +41,13 @@ class Substring extends AbstractOperator
         $result = new \stdClass();
         $result->label = $this->label;
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
 
-        if (!$childs) {
+        if (!$children) {
             return $result;
         } else {
-            $c = $childs[0];
+            $c = $children[0];
 
             $valueArray = [];
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);

--- a/src/GraphQL/Query/Operator/Thumbnail.php
+++ b/src/GraphQL/Query/Operator/Thumbnail.php
@@ -51,12 +51,13 @@ class Thumbnail extends AbstractOperator
             return $result;
         }
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
 
-        if (!$childs) {
+        if (!$children) {
             return $result;
         } else {
-            $c = $childs[0];
+            $c = $children[0];
 
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 

--- a/src/GraphQL/Query/Operator/ThumbnailHtml.php
+++ b/src/GraphQL/Query/Operator/ThumbnailHtml.php
@@ -57,7 +57,9 @@ class ThumbnailHtml extends AbstractOperator
         $result->label = $this->label;
         $result->value = null;
 
-        $children = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
+
         if ($children && $this->thumbnailHtmlConfig) {
             $c = $children[0];
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);

--- a/src/GraphQL/Query/Operator/TranslateValue.php
+++ b/src/GraphQL/Query/Operator/TranslateValue.php
@@ -41,9 +41,11 @@ class TranslateValue extends AbstractOperator
 
         $translator = $this->getGraphQlService()->getTranslator();
 
-        $childs = $this->getChilds();
-        if ($childs[0]) {
-            $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($childs[0]);
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
+
+        if ($children[0]) {
+            $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($children[0]);
 
             $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);
             if ($childResult) {

--- a/src/GraphQL/Query/Operator/Trimmer.php
+++ b/src/GraphQL/Query/Operator/Trimmer.php
@@ -39,12 +39,13 @@ class Trimmer extends AbstractOperator
         $result = new \stdClass();
         $result->label = $this->label;
 
-        $childs = $this->getChilds();
+        // Pimcore 5/6 compatibility
+        $children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
 
-        if (!$childs) {
+        if (!$children) {
             return $result;
         } else {
-            $c = $childs[0];
+            $c = $children[0];
 
             $valueArray = [];
 

--- a/src/GraphQL/Resolver/Base.php
+++ b/src/GraphQL/Resolver/Base.php
@@ -71,8 +71,8 @@ class Base
      */
     public function getResolverAttribute(string $type): string
     {
-        if (isset($this->attributes['childs'][0]) && !empty($this->attributes['childs'][0])) {
-            return $this->attributes['childs'][0]['attributes'][$type];
+        if (isset($this->attributes['children'][0]) && !empty($this->attributes['children'][0])) {
+            return $this->attributes['children'][0]['attributes'][$type];
         } else {
             return null;
         }

--- a/src/GraphQL/Type/MergeType.php
+++ b/src/GraphQL/Type/MergeType.php
@@ -80,8 +80,8 @@ class MergeType extends UnionType implements ContainerAwareInterface
         $attributes = $nodeDef['attributes'];
         $fieldHelper = $this->getGraphQlService()->getObjectFieldHelper();
 
-        if ($attributes['childs']) {
-            foreach ($attributes['childs'] as $childDef) {
+        if ($attributes['children']) {
+            foreach ($attributes['children'] as $childDef) {
                 $type = $fieldHelper->getGraphQlTypeFromNodeConf($childDef, $this->class, $this->container);
                 $childTypes[] = $type;
             }

--- a/src/Resources/public/js/fieldConfigDialog.js
+++ b/src/Resources/public/js/fieldConfigDialog.js
@@ -84,10 +84,10 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                 if (configElement) {
                     var treenode = configElement.getConfigTreeNode(configuration[i].attributes);
 
-                    if (configuration[i].attributes && configuration[i].attributes.childs) {
-                        var childs = this.doBuildChannelConfigTree(configuration[i].attributes.childs);
-                        treenode.children = childs;
-                        if (childs.length > 0) {
+                    if (configuration[i].attributes && configuration[i].attributes.children) {
+                        var children = this.doBuildChannelConfigTree(configuration[i].attributes.children);
+                        treenode.children = children;
+                        if (children.length > 0) {
                             treenode.expandable = true;
                         }
                     }
@@ -134,19 +134,19 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
 
 
     doGetRecursiveData: function (node) {
-        var childs = [];
+        var children = [];
         node.eachChild(function (child) {
             var attributes = child.data.configAttributes;
-            attributes.childs = this.doGetRecursiveData(child);
+            attributes.children = this.doGetRecursiveData(child);
             var childConfig = {
-                "isOperator": child.data.isOperator ? true : false,
+                "isOperator": !!child.data.isOperator,
                 "attributes": attributes
             };
 
-            childs.push(childConfig);
+            children.push(childConfig);
         }.bind(this));
 
-        return childs;
+        return children;
     },
 
 
@@ -164,8 +164,8 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
 
                 if (child.data.isOperator) {
                     var attributes = child.data.configAttributes;
-                    var operatorChilds = this.doGetRecursiveData(child);
-                    attributes.childs = operatorChilds;
+                    var operatorChildren = this.doGetRecursiveData(child);
+                    attributes.children = operatorChildren;
                     operatorFound = true;
 
                     obj.isOperator = true;
@@ -232,7 +232,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
     getSelectionPanel: function () {
         if (!this.selectionPanel) {
 
-            var childs = [];
+            var children = [];
             for (var i = 0; i < this.columnConfig.columns.length; i++) {
                 var nodeConf = this.columnConfig.columns[i];
 
@@ -263,7 +263,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                         child.width = attributes.width;
                     }
                 }
-                childs.push(child);
+                children.push(child);
             }
 
             this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
@@ -282,7 +282,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                     leaf: false,
                     isTarget: true,
                     expanded: true,
-                    children: childs
+                    children: children
                 }
             });
 
@@ -647,8 +647,8 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
 
         for (i = 0; i < len; i++) {
             var k = groupKeys[i];
-            var childs = groups[k];
-            childs.sort(
+            var children = groups[k];
+            children.sort(
                 function (x, y) {
                     return x.text < y.text ? -1 : 1;
                 }
@@ -661,7 +661,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                 allowDrop: false,
                 leaf: false,
                 expanded: true,
-                children: childs
+                children: children
             };
 
             groupNodes.push(groupNode);

--- a/src/Resources/public/js/fieldConfigDialog.js
+++ b/src/Resources/public/js/fieldConfigDialog.js
@@ -84,10 +84,10 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                 if (configElement) {
                     var treenode = configElement.getConfigTreeNode(configuration[i].attributes);
 
-                    if (configuration[i].attributes && configuration[i].attributes.children) {
-                        var children = this.doBuildChannelConfigTree(configuration[i].attributes.children);
-                        treenode.children = children;
-                        if (children.length > 0) {
+                    if (configuration[i].attributes && configuration[i].attributes.childs) {
+                        var childs = this.doBuildChannelConfigTree(configuration[i].attributes.childs);
+                        treenode.children = childs;
+                        if (childs.length > 0) {
                             treenode.expandable = true;
                         }
                     }
@@ -134,19 +134,19 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
 
 
     doGetRecursiveData: function (node) {
-        var children = [];
+        var childs = [];
         node.eachChild(function (child) {
             var attributes = child.data.configAttributes;
-            attributes.children = this.doGetRecursiveData(child);
+            attributes.childs = this.doGetRecursiveData(child);
             var childConfig = {
-                "isOperator": !!child.data.isOperator,
+                "isOperator": child.data.isOperator ? true : false,
                 "attributes": attributes
             };
 
-            children.push(childConfig);
+            childs.push(childConfig);
         }.bind(this));
 
-        return children;
+        return childs;
     },
 
 
@@ -164,8 +164,8 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
 
                 if (child.data.isOperator) {
                     var attributes = child.data.configAttributes;
-                    var operatorChildren = this.doGetRecursiveData(child);
-                    attributes.children = operatorChildren;
+                    var operatorChilds = this.doGetRecursiveData(child);
+                    attributes.childs = operatorChilds;
                     operatorFound = true;
 
                     obj.isOperator = true;
@@ -232,7 +232,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
     getSelectionPanel: function () {
         if (!this.selectionPanel) {
 
-            var children = [];
+            var childs = [];
             for (var i = 0; i < this.columnConfig.columns.length; i++) {
                 var nodeConf = this.columnConfig.columns[i];
 
@@ -263,7 +263,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                         child.width = attributes.width;
                     }
                 }
-                children.push(child);
+                childs.push(child);
             }
 
             this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
@@ -282,7 +282,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                     leaf: false,
                     isTarget: true,
                     expanded: true,
-                    children: children
+                    children: childs
                 }
             });
 
@@ -647,8 +647,8 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
 
         for (i = 0; i < len; i++) {
             var k = groupKeys[i];
-            var children = groups[k];
-            children.sort(
+            var childs = groups[k];
+            childs.sort(
                 function (x, y) {
                     return x.text < y.text ? -1 : 1;
                 }
@@ -661,7 +661,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                 allowDrop: false,
                 leaf: false,
                 expanded: true,
-                children: children
+                children: childs
             };
 
             groupNodes.push(groupNode);

--- a/src/WorkspaceHelper.php
+++ b/src/WorkspaceHelper.php
@@ -135,15 +135,15 @@ class WorkspaceHelper
             }
 
             // exception for read permission
-            if (empty($permissionsParent) && $type == 'read') {
-                // check for childs with permissions
+            if (empty($permissionsParent) && $type === 'read') {
+                // check for children with permissions
                 $path = $element->getRealFullPath() . '/';
-                if ($element->getId() == 1) {
+                if ($element->getId() === 1) {
                     $path = '/';
                 }
 
-                $permissionsChilds = $db->fetchOne('SELECT ' . $type . ' FROM plugin_datahub_workspaces_' . $elementType . ' WHERE cpath LIKE ? AND configuration = ' . $db->quote($configuration->getName()). ' AND ' . $type . ' = 1 LIMIT 1', $path . '%');
-                if ($permissionsChilds) {
+                $permissionsChildren = $db->fetchOne('SELECT ' . $type . ' FROM plugin_datahub_workspaces_' . $elementType . ' WHERE cpath LIKE ? AND configuration = ' . $db->quote($configuration->getName()). ' AND ' . $type . ' = 1 LIMIT 1', $path . '%');
+                if ($permissionsChildren) {
                     return true;
                 }
             }


### PR DESCRIPTION
Resolves #59.

Also changes related verbiage while attempting to retain Pimcore 5 compatibility by checking for:
```php
$children = method_exists($this, 'getChildren') ? $this->getChildren() : $this->getChilds();
```
That should be easy enough to remove in a future update when Pimcore 5 support is dropped.