### PR TITLE
Bugfix: Hotspotimage renamed broke imagegalleries

### DIFF
--- a/src/GraphQL/QueryFieldConfigGenerator/Hotspotimage.php
+++ b/src/GraphQL/QueryFieldConfigGenerator/Hotspotimage.php
@@ -24,6 +24,8 @@ use Pimcore\Model\DataObject\ClassDefinition\Data;
  */
 class Hotspotimage extends Base
 {
+    public const TYPE = 'object_datatype_hotspotimage';
+
     /**
      * @param $attribute
      * @param Data $fieldDefinition

--- a/src/GraphQL/QueryFieldConfigGenerator/ImageGallery.php
+++ b/src/GraphQL/QueryFieldConfigGenerator/ImageGallery.php
@@ -55,7 +55,7 @@ class ImageGallery extends Base
      */
     public function getFieldType(Data $fieldDefinition, $class = null, $container = null)
     {
-        $hotspotType = $this->getGraphQlService()->getTypeDefinition("hotspot");
+        $hotspotType = $this->getGraphQlService()->getTypeDefinition(Hotspotimage::TYPE);
         return Type::listOf($hotspotType);
     }
 


### PR DESCRIPTION
Fix for **unknown type: hotspot** thrown in [GraphQL/Service.php](https://github.com/pimcore/data-hub/blob/master/src/GraphQL/Service.php#L449), introduced due to change in graphql.yml