### PR TITLE
Updates QueryType to align with array arguments

### DIFF
--- a/src/GraphQL/Resolver/QueryType.php
+++ b/src/GraphQL/Resolver/QueryType.php
@@ -292,10 +292,11 @@ class QueryType
         }
 
         // sorting
-        if (isset($args['sortBy'])) {
-            $order = $args['sortOrder'] ? $args['sortOrder'] : 'ASC';
+        if (!empty($args['sortBy'])) {
             $objectList->setOrderKey($args['sortBy']);
-            $objectList->setOrder($order);
+            if (!empty($args['sortOrder'])) {
+                $objectList->setOrder($args['sortOrder']);
+            }
         }
 
         // Include unpublished


### PR DESCRIPTION
Even if the GQL would complain about using a string where an array of strings were used in the query the listing would accept it, this caused a slight mismatch when running automated queries.