### PR TITLE
Config improvements

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -182,7 +182,7 @@ class Configuration extends AbstractModel
      */
     public static function getList()
     {
-        $config = new self(null);
+        $config = new self(null, null);
 
         return $config->getDao()->getList();
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -18,6 +18,10 @@ namespace Pimcore\Bundle\DataHubBundle;
 use Pimcore\Bundle\DataHubBundle\Configuration\Dao;
 use Pimcore\Model\AbstractModel;
 
+/**
+ * Class Configuration
+ * @package Pimcore\Bundle\DataHubBundle
+ */
 class Configuration extends AbstractModel
 {
     /**
@@ -50,11 +54,11 @@ class Configuration extends AbstractModel
      */
     public function __construct($type, $path, $name = null, $configuration = null)
     {
-        $type = $type ? $type : 'graphql';
+        $type = $type ?: 'graphql';
         $this->type = $type;
         $this->path = $path;
         $this->name = $name;
-        $this->configuration = $configuration ? $configuration : [];
+        $this->configuration = $configuration ?: [];
     }
 
     /**
@@ -76,7 +80,7 @@ class Configuration extends AbstractModel
     /**
      * @param mixed $configuration
      */
-    public function setConfiguration($configuration)
+    public function setConfiguration($configuration): void
     {
         if (is_array($configuration)) {
             $configuration = json_decode(json_encode($configuration), true);
@@ -93,17 +97,17 @@ class Configuration extends AbstractModel
     }
 
     /**
-     * @param mixed $name
+     * @param string $name
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -111,7 +115,7 @@ class Configuration extends AbstractModel
     /**
      * @return string|null
      */
-    public function getSqlObjectCondition()
+    public function getSqlObjectCondition(): ?string
     {
         return $this->configuration && $this->configuration['general'] ? $this->configuration['general']['sqlObjectListCondition'] : null;
     }
@@ -125,17 +129,17 @@ class Configuration extends AbstractModel
     }
 
     /**
-     * @param $path
+     * @param string $path
      */
-    public function setPath($path)
+    public function setPath($path): void
     {
         $this->path = $path;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getPath()
+    public function getPath(): ?string
     {
         return $this->path;
     }
@@ -192,7 +196,7 @@ class Configuration extends AbstractModel
      *
      * @return Configuration|null
      */
-    public static function getByName($name)
+    public static function getByName($name): ?Configuration
     {
         return Dao::getByName($name);
     }
@@ -219,7 +223,6 @@ class Configuration extends AbstractModel
 
         return $entities;
     }
-
 
     /**
      * @return array

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -19,7 +19,6 @@ use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Bundle\DataHubBundle\Configuration\Dao;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -30,7 +29,16 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminController
 {
-    private function buildFolder($path, $name)
+    public const CONFIG_NAME = 'plugin_datahub_config';
+
+    /**
+     * @param $path
+     *
+     * @param $name
+     *
+     * @return array
+     */
+    private function buildFolder($path, $name): array
     {
         return [
             'id' => $path,
@@ -47,10 +55,9 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return array
      */
-    private function buildItem($configuration)
-
+    private function buildItem($configuration): array
     {
-        $type = $configuration->getType() ? $configuration->getType() : 'graphql';
+        $type = $configuration->getType() ?: 'graphql';
 
         return [
             'id' => $configuration->getName(),
@@ -69,11 +76,10 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function listAction(Request $request)
+    public function listAction(Request $request): JsonResponse
     {
-
         // check permissions
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         $folders = Dao::getFolders();
         $list = Dao::getList();
@@ -88,7 +94,7 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
             // root folders, keep a pointer to 1 dimensional array
             // to minimize memory and actually make the nesting work
             if (empty($folder['parent'])) {
-                $tree[] = & $folderStructure[$folder['path']];
+                $tree[] = &$folderStructure[$folder['path']];
             }
         }
 
@@ -108,10 +114,8 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
 
             if (!$configuration->getPath()) {
                 $tree[] = $config;
-            } else {
-                if (!empty($folderStructure[$configuration->getPath()])) {
-                    $folderStructure[$configuration->getPath()]['children'][] = $config;
-                }
+            } elseif (!empty($folderStructure[$configuration->getPath()])) {
+                $folderStructure[$configuration->getPath()]['children'][] = $config;
             }
         }
 
@@ -124,17 +128,19 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      * @param Request $request
      *
      * @return JsonResponse
+     *
+     * @throws \Exception
      */
-    public function deleteAction(Request $request)
+    public function deleteAction(Request $request): ?JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         try {
             $name = $request->get('name');
 
             $config = Dao::getByName($name);
-            if (empty($config)) {
-                throw new Exception('Name does not exist.');
+            if ($config instanceof Configuration) {
+                throw new \Exception('Name does not exist.');
             }
 
             WorkspaceHelper::deleteConfiguration($config);
@@ -142,7 +148,7 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
             $config->delete();
 
             return $this->json(['success' => true]);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->json(['success' => false, 'message' => $e->getMessage()]);
         }
     }
@@ -151,14 +157,14 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      * @Route("/add-folder")
      *
      * @param Request $request
-     * 
+     *
      * @throws \Exception
      *
      * @return JsonResponse
      */
-    public function addFolderAction(Request $request)
+    public function addFolderAction(Request $request): ?JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         $parent = $request->get('parent');
         $name = $request->get('name');
@@ -171,8 +177,8 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
             Dao::addFolder($parent, $name);
 
             return $this->json(['success' => true]);
-        } catch (Exception $exception) {
-            return $this->json(['success' => false, 'message' => $exception->getMessage()]);
+        } catch (\Exception $e) {
+            return $this->json(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -183,9 +189,9 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function deleteFolderAction(Request $request)
+    public function deleteFolderAction(Request $request): ?JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         $path = $request->get('path');
 
@@ -205,9 +211,9 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function moveAction(Request $request)
+    public function moveAction(Request $request): JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         $who = $request->get('who');
         $to = $request->get('to');
@@ -224,9 +230,9 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function moveFolderAction(Request $request)
+    public function moveFolderAction(Request $request): JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         $who = $request->get('who');
         $to = $request->get('to');
@@ -245,9 +251,9 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function addAction(Request $request)
+    public function addAction(Request $request): ?JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         try {
             $path = $request->get('path');
@@ -256,15 +262,15 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
 
             $config = Dao::getByName($name);
 
-            if (!empty($config)) {
-                throw new Exception('Name already exists.');
+            if ($config instanceof Configuration) {
+                throw new \Exception('Name already exists.');
             }
 
             $config = new Configuration($type, $path, $name);
             $config->save();
 
             return $this->json(['success' => true, 'name' => $name]);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->json(['success' => false, 'message' => $e->getMessage()]);
         }
     }
@@ -278,29 +284,29 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function cloneAction(Request $request)
+    public function cloneAction(Request $request): ?JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         try {
             $name = $request->get('name');
 
             $config = Dao::getByName($name);
-            if (!empty($config)) {
-                throw new Exception('Name already exists.');
+            if ($config instanceof Configuration) {
+                throw new \Exception('Name already exists.');
             }
 
             $originalName = $request->get('originalName');
             $originalConfig = Dao::getByName($originalName);
             if (!$originalConfig) {
-                throw new Exception('Configuration not found');
+                throw new \Exception('Configuration not found');
             }
 
             $originalConfig->setName($name);
             $originalConfig->save();
 
             return $this->json(['success' => true, 'name' => $name]);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->json(['success' => false, 'message' => $e->getMessage()]);
         }
     }
@@ -315,22 +321,21 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function getAction(Request $request, Service $graphQlService)
+    public function getAction(Request $request, Service $graphQlService): JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         $name = $request->get('name');
 
         $configuration = Dao::getByName($name);
-        if (empty($configuration)) {
-            throw new Exception('Datahub configuration ' . $name . ' does not exist.');
+        if (!$configuration) {
+            throw new \Exception('Datahub configuration ' . $name . ' does not exist.');
         }
 
         $config = $configuration->getConfiguration();
-        $config['schema']['queryEntities'] = array_values($config['schema']['queryEntities'] ? $config['schema']['queryEntities'] : []);
-        $config['schema']['mutationEntities'] = array_values($config['schema']['mutationEntities'] ? $config['schema']['mutationEntities'] : []);
-        $config['schema']['specialEntities'] = $config['schema']['specialEntities'] ? $config['schema']['specialEntities'] : [];
-
+        $config['schema']['queryEntities'] = array_values($config['schema']['queryEntities'] ?: []);
+        $config['schema']['mutationEntities'] = array_values($config['schema']['mutationEntities'] ?: []);
+        $config['schema']['specialEntities'] = $config['schema']['specialEntities'] ?: [];
 
         if (!$config['schema']['specialEntities']) {
             $config['schema']['specialEntities'] = [];
@@ -368,9 +373,9 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function saveAction(Request $request)
+    public function saveAction(Request $request): ?JsonResponse
     {
-        $this->checkPermission('plugin_datahub_config');
+        $this->checkPermission(self::CONFIG_NAME);
 
         try {
             $data = $request->get('data');
@@ -394,7 +399,7 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
             $config->save();
 
             return $this->json(['success' => true]);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->json(['success' => false, 'message' => $e->getMessage()]);
         }
     }
@@ -409,7 +414,7 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
      *
      * @return JsonResponse
      */
-    public function getExplorerUrlAction(RouterInterface $routingService, Request $request)
+    public function getExplorerUrlAction(RouterInterface $routingService, Request $request): ?JsonResponse
     {
         $name = $request->get('name');
 

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -139,7 +139,7 @@ class ConfigController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContr
             $name = $request->get('name');
 
             $config = Dao::getByName($name);
-            if ($config instanceof Configuration) {
+            if (!$config instanceof Configuration) {
                 throw new \Exception('Name does not exist.');
             }
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\DataHubBundle;
 
+use Pimcore\Bundle\DataHubBundle\Controller\ConfigController;
 use Pimcore\Db;
 use Pimcore\Extension\Bundle\Installer\AbstractInstaller;
 use Pimcore\Logger;
@@ -24,18 +25,15 @@ class Installer extends AbstractInstaller
     /**
      * {@inheritdoc}
      */
-    public function isInstalled()
+    public function isInstalled(): bool
     {
         $db = Db::get();
-        $check = $db->fetchRow("SELECT * FROM users_permission_definitions where `key`='plugin_datahub_config'");
-        if (!$check) {
-            return false;
-        }
+        $check = $db->fetchOne("SELECT `key` FROM users_permission_definitions where `key` = ?", [ConfigController::CONFIG_NAME]);
 
-        return true;
+        return (bool) $check;
     }
 
-    public function needsReloadAfterInstall()
+    public function needsReloadAfterInstall(): bool
     {
         return true;
     }
@@ -43,7 +41,7 @@ class Installer extends AbstractInstaller
     /**
      * {@inheritdoc}
      */
-    public function canBeInstalled()
+    public function canBeInstalled(): bool
     {
         return !$this->isInstalled();
     }
@@ -54,7 +52,7 @@ class Installer extends AbstractInstaller
     public function install()
     {
         // create backend permission
-        \Pimcore\Model\User\Permission\Definition::create('plugin_datahub_config');
+        \Pimcore\Model\User\Permission\Definition::create(ConfigController::CONFIG_NAME);
 
         try {
             $db = Db::get();

--- a/src/Resources/public/js/configItem.js
+++ b/src/Resources/public/js/configItem.js
@@ -141,7 +141,8 @@ pimcore.plugin.datahub.configItem = Class.create(pimcore.element.abstract, {
                     name: "name",
                     value: this.data.general.name,
                     readOnly: true
-                }, {
+                },
+                {
                     name: "description",
                     fieldLabel: t("description"),
                     xtype: "textarea",
@@ -150,9 +151,10 @@ pimcore.plugin.datahub.configItem = Class.create(pimcore.element.abstract, {
                 },
                 {
                     xtype: "displayfield",
+                    hideLabel: true,
                     value: t("plugin_pimcore_datahub_configpanel_condition_hint"),
-                    name: "sql_list_hint",
-                    readOnly: true
+                    readOnly: true,
+                    disabled: true
                 },
                 {
                     name: "sqlObjectCondition",
@@ -231,7 +233,9 @@ pimcore.plugin.datahub.configItem = Class.create(pimcore.element.abstract, {
                     xtype: 'displayfield',
                     hideLabel: true,
                     value: t("plugin_pimcore_datahub_security_apikey_description"),
-                    cls: "pimcore_extra_label_bottom"
+                    cls: "pimcore_extra_label_bottom",
+                    readOnly: true,
+                    disabled: true
                 },
                 {
                     xtype: 'fieldset',
@@ -474,13 +478,11 @@ pimcore.plugin.datahub.configItem = Class.create(pimcore.element.abstract, {
         });
     },
 
-
     getSaveData: function () {
-
         var saveData = {};
-        saveData["general"] = this.generalForm.getForm().getFieldValues();
+        saveData["general"] = this.generalForm.getForm().getFieldValues(false, false);
         saveData["schema"] = this.schemaForm.getForm().getFieldValues();
-        saveData["security"] = this.securityForm.getForm().getFieldValues();
+        saveData["security"] = this.securityForm.getForm().getFieldValues(false, false);
         saveData["schema"]["queryEntities"] = this.getSchemaData("query");
         saveData["schema"]["mutationEntities"] = this.getSchemaData("mutation");
         saveData["schema"]["specialEntities"] = this.getSchemaData("special");
@@ -489,7 +491,6 @@ pimcore.plugin.datahub.configItem = Class.create(pimcore.element.abstract, {
         saveData["workspaces"]["object"] = this.objectWorkspace.getValues();
         return Ext.encode(saveData);
     },
-
 
     getSchemaData: function (type) {
         var tmData = [];


### PR DESCRIPTION
Resolves #97 

However, this PR does not yet touch the `"key" => "#5d..."` in datahub-configuration.php (because I don't understand it yet) but does a number of other things:

* Adds return types, implements class constant for reused string, normalises Exception class import according to comments, moves to shorthand ifs (`?:`) for configController.php
* Adds return types, normalises Exception throwing, adds access keywords, and method docs for Dao.php
* Adds return types, simplifies IsInstalled() logic, uses ConfigController constant for name in Installer.php
* Prevents SQL hint and API info from saving in datahub-configuration.php