### PR TITLE
Fixes bug with an empty field in an image gallery

### DIFF
--- a/src/GraphQL/QueryFieldConfigGenerator/Helper/ImageGallery.php
+++ b/src/GraphQL/QueryFieldConfigGenerator/Helper/ImageGallery.php
@@ -82,6 +82,8 @@ class ImageGallery
             foreach ($relations as $relation) {
                 if ($relation instanceof Hotspotimage) {
                     $image = $relation->getImage();
+                } else {
+                    continue;
                 }
 
                 if ($image instanceof Asset) {


### PR DESCRIPTION
For example, if you have three images in three of four fields in the gallery and the fourth field is empty, this will no longer cause query to fail.

`$relation` will be `null`, but `$image` will still be available from last loop and cause trouble