### PR TITLE
Fixes Pimcore\Composer::clearCache fatal error

### DIFF
--- a/src/Resources/config/graphql.yml
+++ b/src/Resources/config/graphql.yml
@@ -327,7 +327,6 @@ services:
       $className: Pimcore\Bundle\DataHubBundle\GraphQL\Query\Operator\Text
     tags:
       - { name: pimcore.datahub.graphql.dataobjectqueryoperator_factory, id: text }
-      -
 
   #
   # type definitions


### PR DESCRIPTION
Error when installing/updating

```
Script Pimcore\Composer::clearCache handling the pimcore-scripts event terminated with an exception

                                                                                                                                                                                             
  [RuntimeException]                                                                                                                                                                         
  An error occurred when executing the "'cache:clear --no-warmup'" command:                                                                                                                  
                                                                                                                                                                                             
                                                                                                                                                                                             
  Fatal error: Uncaught Symfony\Component\DependencyInjection\Exception\InvalidArgumentException: A "tags" entry is missing a "name" key for service "pimcore.datahub.graphql.dataobjectque  
  ryoperator.factory.text" in /var/www/pimcore/vendor/pimcore/data-hub/src/DependencyInjection/../Resources/config/graphql.yml. in /var/www/pimcore/vendor/symfony/symfony/src/Symfony/Comp  
  onent/Config/Loader/FileLoader.php on line 166                                                                                                                                             
                                                                                                                                                                                             
  Symfony\Component\Config\Exception\LoaderLoadException: A "tags" entry is missing a "name" key for service "pimcore.datahub.graphql.dataobjectqueryoperator.factory.text" in /var/www/pim  
  core/vendor/pimcore/data-hub/src/DependencyInjection/../Resources/config/graphql.yml in /var/www/pimcore/vendor/pimcore/data-hub/src/DependencyInjection/../Resources/config/graphql.yml   
  (which is being imported from "/var/www/pimcore/vendor/pimcore/data-hub/src/DependencyInjection/../Resources/config/services.yml"). in /var/www/pimcore/vendor/symfony/symfony/src/Symfon  
  y/Component/Config/Loader/FileLoader.php on line 166                                                                                                                                       
                                                                                                                                                                                             
  Call Stack:                                                                                                                                                                                
      7.0317   16482816   1. Symfony\Component\Debug\ErrorHandler->handleException(???, ???) /var/www/pimcore/vendor/symfony/symfony/src/Symfony/Component/Debug/ErrorHandler.php:0          
```