### PR TITLE
Replace plugin to bundle in frontend namespace

### DIFF
--- a/doc/graphl/AddCustomMutationOperator.md
+++ b/doc/graphl/AddCustomMutationOperator.md
@@ -29,7 +29,7 @@ and the server-side PHP implementation processing the input (the input processor
 A JS sample can be found here:
 https://github.com/pimcore/data-hub/blob/master/src/Resources/public/js/mutationoperator/IfEmpty.js
 
-Note that the namespace in your case would be `pimcore.plugin.datahub.mutationoperator.mycustommutationoperator`
+Note that the namespace in your case would be `pimcore.bundle.datahub.mutationoperator.mycustommutationoperator`
 
 Make sure that your extension gets loaded. See [Pimcore Bundles](https://pimcore.com/docs/5.x/Development_Documentation/Extending_Pimcore/Bundle_Developers_Guide/Pimcore_Bundles/index.html)
 docs page for further details.

--- a/doc/graphl/AddCustomQueryOperator.md
+++ b/doc/graphl/AddCustomQueryOperator.md
@@ -24,7 +24,7 @@ You have to provide both JavaScript code dealing with the UI configuration aspec
 and the server-side PHP implementation doing the actual calculations. 
 
 A JS sample can be found here: https://github.com/pimcore/data-hub/blob/7c62b888014a3df37928867b89b0dcd4489c3df4/src/Resources/public/js/operator/Trimmer
-Note that the namespace would be `pimcore.plugin.datahub.operator.mycustomoperator`
+Note that the namespace would be `pimcore.bundle.datahub.operator.mycustomoperator`
 
 Make sure that your extension gets loaded. See [Pimcore Bundles](https://pimcore.com/docs/5.x/Development_Documentation/Extending_Pimcore/Bundle_Developers_Guide/Pimcore_Bundles/index.html)
 docs page for further details.

--- a/src/Resources/public/js/Abstract.js
+++ b/src/Resources/public/js/Abstract.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.Abstract");
-
-pimcore.plugin.datahub.Abstract = Class.create({
+pimcore.registerNS("pimcore.bundle.datahub.Abstract");
+pimcore.bundle.datahub.Abstract = Class.create({
     type: null,
     class: null,
     objectClassId: null,

--- a/src/Resources/public/js/config.js
+++ b/src/Resources/public/js/config.js
@@ -11,9 +11,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-pimcore.registerNS("pimcore.plugin.datahub.config");
-pimcore.plugin.datahub.config = Class.create({
-
+pimcore.registerNS("pimcore.bundle.datahub.config");
+pimcore.bundle.datahub.config = Class.create({
     initialize: function () {
 
         this.getTabPanel();
@@ -155,11 +154,11 @@ pimcore.plugin.datahub.config = Class.create({
             success: function (response) {
                 var data = Ext.decode(response.responseText);
 
-                pimcore.plugin.datahub.graphql = pimcore.plugin.datahub.graphql || {};
-                pimcore.plugin.datahub.graphql.supportedQueryDataTypes = data.supportedGraphQLQueryDataTypes;
-                pimcore.plugin.datahub.graphql.supportedMutationDataTypes = data.supportedGraphQLMutationDataTypes;
+                pimcore.bundle.datahub.graphql = pimcore.bundle.datahub.graphql || {};
+                pimcore.bundle.datahub.graphql.supportedQueryDataTypes = data.supportedGraphQLQueryDataTypes;
+                pimcore.bundle.datahub.graphql.supportedMutationDataTypes = data.supportedGraphQLMutationDataTypes;
 
-                var fieldPanel = new pimcore.plugin.datahub.configItem(data, this);
+                var fieldPanel = new pimcore.bundle.datahub.configItem(data, this);
                 pimcore.layout.refresh();
             }.bind(this)
         });

--- a/src/Resources/public/js/datahub.js
+++ b/src/Resources/public/js/datahub.js
@@ -12,7 +12,7 @@
  */
 
 pimcore.registerNS("pimcore.bundle.datahub");
-pimcore.bundle.datahub = Class.create(pimcore.bundle.admin, {
+pimcore.bundle.datahub = Class.create(pimcore.plugin.admin, {
     getClassName: function () {
         return "pimcore.bundle.datahub";
     },

--- a/src/Resources/public/js/datahub.js
+++ b/src/Resources/public/js/datahub.js
@@ -11,11 +11,10 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-pimcore.registerNS("pimcore.plugin.datahub");
-
-pimcore.plugin.datahub = Class.create(pimcore.plugin.admin, {
+pimcore.registerNS("pimcore.bundle.datahub");
+pimcore.bundle.datahub = Class.create(pimcore.bundle.admin, {
     getClassName: function () {
-        return "pimcore.plugin.datahub";
+        return "pimcore.bundle.datahub";
     },
 
     initialize: function () {
@@ -37,7 +36,7 @@ pimcore.plugin.datahub = Class.create(pimcore.plugin.admin, {
                         pimcore.globalmanager.get("plugin_pimcore_datahub_config").activate();
                     }
                     catch (e) {
-                        pimcore.globalmanager.add("plugin_pimcore_datahub_config", new pimcore.plugin.datahub.config());
+                        pimcore.globalmanager.add("plugin_pimcore_datahub_config", new pimcore.bundle.datahub.config());
                     }
                 }
             });
@@ -45,5 +44,5 @@ pimcore.plugin.datahub = Class.create(pimcore.plugin.admin, {
     }
 });
 
-var dtaPlugin = new pimcore.plugin.datahub();
+var dtaPlugin = new pimcore.bundle.datahub();
 

--- a/src/Resources/public/js/fieldConfigDialog.js
+++ b/src/Resources/public/js/fieldConfigDialog.js
@@ -11,9 +11,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-pimcore.registerNS("pimcore.plugin.datahub.fieldConfigDialog");
-pimcore.plugin.datahub.fieldConfigDialog = Class.create({
-
+pimcore.registerNS("pimcore.bundle.datahub.fieldConfigDialog");
+pimcore.bundle.datahub.fieldConfigDialog = Class.create({
     showFieldname: true,
     data: {},
     brickKeys: [],
@@ -586,7 +585,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
     },
 
     getOperatorTrees: function () {
-        var operators = pimcore.plugin.datahub[this.type + "operator"] ? Object.keys(pimcore.plugin.datahub[this.type + "operator"]) : [];
+        var operators = pimcore.bundle.datahub[this.type + "operator"] ? Object.keys(pimcore.bundle.datahub[this.type + "operator"]) : [];
         var operatorGroups = [];
 
         for (var i = 0; i < operators.length; i++) {
@@ -596,7 +595,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
                 continue;
             }
             if (!this.availableOperators || this.availableOperators.indexOf(operator) >= 0) {
-                var nodeConfig = pimcore.plugin.datahub[this.type + "operator"][operator].prototype;
+                var nodeConfig = pimcore.bundle.datahub[this.type + "operator"][operator].prototype;
                 var configTreeNode = nodeConfig.getConfigTreeNode();
 
                 var operatorGroup = nodeConfig.operatorGroup ? nodeConfig.operatorGroup : "other";
@@ -724,15 +723,15 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
         var attributes = configAttributes.attributes;
         if (attributes && attributes.class && attributes.type) {
             var jsClass = attributes.class.toLowerCase();
-            if (pimcore.plugin.datahub[this.type + attributes.type] && pimcore.plugin.datahub[this.type + attributes.type][jsClass]) {
-                element = new pimcore.plugin.datahub[this.type + attributes.type][jsClass](this.generalConfig.classId);
+            if (pimcore.bundle.datahub[this.type + attributes.type] && pimcore.bundle.datahub[this.type + attributes.type][jsClass]) {
+                element = new pimcore.bundle.datahub[this.type + attributes.type][jsClass](this.generalConfig.classId);
             }
         } else {
             var dataType = configAttributes.dataType ? configAttributes.dataType.toLowerCase() : null;
-            if (pimcore.plugin.datahub[this.type + "value"] && pimcore.plugin.datahub[this.type + "value"][dataType]) {
-                element = new pimcore.plugin.datahub[this.type + "value"][dataType](this.generalConfig.classId);
+            if (pimcore.bundle.datahub[this.type + "value"] && pimcore.bundle.datahub[this.type + "value"][dataType]) {
+                element = new pimcore.bundle.datahub[this.type + "value"][dataType](this.generalConfig.classId);
             } else {
-                element = new pimcore.plugin.datahub[this.type + "value"]["defaultvalue"](this.generalConfig.classId);
+                element = new pimcore.bundle.datahub[this.type + "value"]["defaultvalue"](this.generalConfig.classId);
             }
         }
         return element;
@@ -741,7 +740,7 @@ pimcore.plugin.datahub.fieldConfigDialog = Class.create({
     checkSupported: function (record) {
         if (record.data.type == "data") {
             var dataType = record.data.dataType;
-            if (dataType != "system" && !in_array(dataType, pimcore.plugin.datahub.graphql["supported" + ucfirst(this.type) + "DataTypes"])) {
+            if (dataType != "system" && !in_array(dataType, pimcore.bundle.datahub.graphql["supported" + ucfirst(this.type) + "DataTypes"])) {
                 Ext.MessageBox.alert(t("error"), sprintf(t("plugin_pimcore_datahub_" + this.type) + " " + t('plugin_pimcore_datahub_datatype_not_supported_yet'), dataType));
                 return false;
             }

--- a/src/Resources/public/js/mutationoperator/IfEmpty.js
+++ b/src/Resources/public/js/mutationoperator/IfEmpty.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.mutationoperator.ifempty");
-
-pimcore.plugin.datahub.mutationoperator.ifempty = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.mutationoperator.ifempty");
+pimcore.bundle.datahub.mutationoperator.ifempty = Class.create(pimcore.bundle.datahub.Abstract, {
     type: "operator",
     class: "IfEmpty",
     iconCls: "plugin_pimcore_datahub_icon_ifempty",

--- a/src/Resources/public/js/mutationoperator/LocaleSwitcher.js
+++ b/src/Resources/public/js/mutationoperator/LocaleSwitcher.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.mutationoperator.localeswitcher");
-
-pimcore.plugin.datahub.mutationoperator.localeswitcher = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.mutationoperator.localeswitcher");
+pimcore.bundle.datahub.mutationoperator.localeswitcher = Class.create(pimcore.bundle.datahub.Abstract, {
     type: "operator",
     class: "LocaleSwitcher",
     iconCls: "pimcore_icon_operator_localeswitcher",

--- a/src/Resources/public/js/mutationvalue/DefaultValue.js
+++ b/src/Resources/public/js/mutationvalue/DefaultValue.js
@@ -14,11 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.mutationvalue.defaultvalue");
-
-pimcore.plugin.datahub.mutationvalue.defaultvalue = Class.create(pimcore.plugin.datahub.Abstract, {
-
+pimcore.registerNS("pimcore.bundle.datahub.mutationvalue.defaultvalue");
+pimcore.bundle.datahub.mutationvalue.defaultvalue = Class.create(pimcore.bundle.datahub.Abstract, {
     type: "value",
     class: "DefaultValue",
 

--- a/src/Resources/public/js/queryoperator/Alias.js
+++ b/src/Resources/public/js/queryoperator/Alias.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.alias");
-
-pimcore.plugin.datahub.queryoperator.alias = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.alias");
+pimcore.bundle.datahub.queryoperator.alias = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "other",
     type: "operator",
     class: "Alias",

--- a/src/Resources/public/js/queryoperator/Concatenator.js
+++ b/src/Resources/public/js/queryoperator/Concatenator.js
@@ -15,9 +15,8 @@
  */
 
 
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.concatenator");
-
-pimcore.plugin.datahub.queryoperator.concatenator = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.concatenator");
+pimcore.bundle.datahub.queryoperator.concatenator = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "transformer",
     type: "operator",
     class: "Concatenator",

--- a/src/Resources/public/js/queryoperator/DateFormatter.js
+++ b/src/Resources/public/js/queryoperator/DateFormatter.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.dateformatter");
-
-pimcore.plugin.datahub.queryoperator.dateformatter = Class.create(pimcore.plugin.datahub.Abstract, {
-
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.dateformatter");
+pimcore.bundle.datahub.queryoperator.dateformatter = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "formatter",
     type: "operator",
     class: "DateFormatter",

--- a/src/Resources/public/js/queryoperator/ElementCounter.js
+++ b/src/Resources/public/js/queryoperator/ElementCounter.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.elementcounter");
-
-pimcore.plugin.datahub.queryoperator.elementcounter = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.elementcounter");
+pimcore.bundle.datahub.queryoperator.elementcounter = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "transformer",
     type: "operator",
     class: "ElementCounter",

--- a/src/Resources/public/js/queryoperator/Merge.js
+++ b/src/Resources/public/js/queryoperator/Merge.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.merge");
-
-pimcore.plugin.datahub.queryoperator.merge = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.merge");
+pimcore.bundle.datahub.queryoperator.merge = Class.create(pimcore.bundle.datahub.Abstract, {
     type: "operator",
     class: "Merge",
     iconCls: "pimcore_icon_operator_merge",

--- a/src/Resources/public/js/queryoperator/Substring.js
+++ b/src/Resources/public/js/queryoperator/Substring.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.substring");
-
-pimcore.plugin.datahub.queryoperator.substring = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.substring");
+pimcore.bundle.datahub.queryoperator.substring = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "transformer",
     type: "operator",
     class: "Substring",

--- a/src/Resources/public/js/queryoperator/Text.js
+++ b/src/Resources/public/js/queryoperator/Text.js
@@ -14,9 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.text");
-
-pimcore.plugin.datahub.queryoperator.text = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.text");
+pimcore.bundle.datahub.queryoperator.text = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "formatter",
     type: "operator",
     class: "Text",

--- a/src/Resources/public/js/queryoperator/Thumbnail.js
+++ b/src/Resources/public/js/queryoperator/Thumbnail.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.thumbnail");
-
-pimcore.plugin.datahub.queryoperator.thumbnail = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.thumbnail");
+pimcore.bundle.datahub.queryoperator.thumbnail = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "transformer",
     type: "operator",
     class: "Thumbnail",

--- a/src/Resources/public/js/queryoperator/ThumbnailHtml.js
+++ b/src/Resources/public/js/queryoperator/ThumbnailHtml.js
@@ -14,9 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.thumbnailhtml");
-
-pimcore.plugin.datahub.queryoperator.thumbnailhtml = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.thumbnailhtml");
+pimcore.bundle.datahub.queryoperator.thumbnailhtml = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "transformer",
     type: "operator",
     class: "ThumbnailHtml",

--- a/src/Resources/public/js/queryoperator/TranslateValue.js
+++ b/src/Resources/public/js/queryoperator/TranslateValue.js
@@ -14,9 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.translatevalue");
-
-pimcore.plugin.datahub.queryoperator.translatevalue = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.translatevalue");
+pimcore.bundle.datahub.queryoperator.translatevalue = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "transformer",
     type: "operator",
     class: "TranslateValue",

--- a/src/Resources/public/js/queryoperator/Trimmer.js
+++ b/src/Resources/public/js/queryoperator/Trimmer.js
@@ -14,10 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.queryoperator.trimmer");
-
-pimcore.plugin.datahub.queryoperator.trimmer = Class.create(pimcore.plugin.datahub.Abstract, {
+pimcore.registerNS("pimcore.bundle.datahub.queryoperator.trimmer");
+pimcore.bundle.datahub.queryoperator.trimmer = Class.create(pimcore.bundle.datahub.Abstract, {
     operatorGroup: "transformer",
     type: "operator",
     class: "Trimmer",

--- a/src/Resources/public/js/queryvalue/DefaultValue.js
+++ b/src/Resources/public/js/queryvalue/DefaultValue.js
@@ -14,11 +14,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.queryvalue.defaultvalue");
-
-pimcore.plugin.datahub.queryvalue.defaultvalue = Class.create(pimcore.plugin.datahub.Abstract, {
-
+pimcore.registerNS("pimcore.bundle.datahub.queryvalue.defaultvalue");
+pimcore.bundle.datahub.queryvalue.defaultvalue = Class.create(pimcore.bundle.datahub.Abstract, {
     type: "value",
     class: "DefaultValue",
 

--- a/src/Resources/public/js/workspace/abstract.js
+++ b/src/Resources/public/js/workspace/abstract.js
@@ -11,10 +11,8 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.workspace.abstract");
-pimcore.plugin.datahub.workspace.abstract = Class.create({
-
+pimcore.registerNS("pimcore.bundle.datahub.workspace.abstract");
+pimcore.bundle.datahub.workspace.abstract = Class.create({
     initialize: function (parent) {
         this.parent = parent;
         this.workspaces = this.parent.data.workspaces;

--- a/src/Resources/public/js/workspace/asset.js
+++ b/src/Resources/public/js/workspace/asset.js
@@ -11,11 +11,7 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.workspace.asset");
-pimcore.plugin.datahub.workspace.asset = Class.create(pimcore.plugin.datahub.workspace.abstract, {
-
-
+pimcore.registerNS("pimcore.bundle.datahub.workspace.asset");
+pimcore.bundle.datahub.workspace.asset = Class.create(pimcore.bundle.datahub.workspace.abstract, {
     type: "asset"
-
 });

--- a/src/Resources/public/js/workspace/document.js
+++ b/src/Resources/public/js/workspace/document.js
@@ -11,11 +11,7 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.workspace.document");
-pimcore.plugin.datahub.workspace.document = Class.create(pimcore.plugin.datahub.workspace.abstract, {
-
-
+pimcore.registerNS("pimcore.bundle.datahub.workspace.document");
+pimcore.bundle.datahub.workspace.document = Class.create(pimcore.bundle.datahub.workspace.abstract, {
     type: "document"
-
 });

--- a/src/Resources/public/js/workspace/object.js
+++ b/src/Resources/public/js/workspace/object.js
@@ -11,9 +11,7 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
-pimcore.registerNS("pimcore.plugin.datahub.workspace.object");
-pimcore.plugin.datahub.workspace.object = Class.create(pimcore.plugin.datahub.workspace.abstract, {
-
+pimcore.registerNS("pimcore.bundle.datahub.workspace.object");
+pimcore.bundle.datahub.workspace.object = Class.create(pimcore.bundle.datahub.workspace.abstract, {
     type: "object"
 });


### PR DESCRIPTION
1. Changed old namespace from Pimcore 4 (.plugin) to Pimcore 5/6 (.bundle) for consistency
2. Removed extra lines in js files 