### PR TITLE
Fixes broken document links

### DIFF
--- a/src/GraphQL/DocumentElementType/LinkType.php
+++ b/src/GraphQL/DocumentElementType/LinkType.php
@@ -54,9 +54,7 @@ class LinkType extends ObjectType
                         'data' => [
                             'type' => $linkDataType,
                             'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                                if ($value) {
-                                    return $value->getData();
-                                }
+                                return $value;
                             }
                         ],
                     ],


### PR DESCRIPTION
The link data type resolver expects an instance of `\Pimcore\Model\Document\Tag\Link`, not an array. See: https://github.com/pimcore/data-hub/blob/683d328da594abdc24661e1006a350b205a9c1db/src/GraphQL/DocumentElementType/LinkDataType.php#L89

Fixes #141.