### PR TITLE
Order document elements by the order they are in blocks

### DIFF
--- a/src/GraphQL/DocumentResolver/PageSnippet.php
+++ b/src/GraphQL/DocumentResolver/PageSnippet.php
@@ -18,6 +18,9 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DocumentResolver;
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
+use Pimcore\Model\Document\Tag;
+use Pimcore\Model\Document\Tag\Areablock;
+use Pimcore\Model\Document\Tag\BlockInterface;
 
 
 class PageSnippet
@@ -40,24 +43,66 @@ class PageSnippet
 
         if ($document instanceof Document\PageSnippet) {
             $result = [];
+            $sortBy = [];
             $elements = $document->getElements();
 
             $service = $this->getGraphQlService();
             $supportedTypeNames = $service->getSupportedDocumentElementQueryDataTypes();
 
-            foreach ($elements as $element) {
+            foreach ($elements as $name => $element) {
                 $elementType = $element->getType();
                 if (in_array($elementType, $supportedTypeNames)) {
                     $result[] = $element;
+                    $sortBy[$name] = $this->getElementSortIndex($name, $elements);
                 }
-
             }
+
+            usort($result, function (Tag $a, Tag $b) use ($sortBy) {
+                // "Natural order" comparison so that "10" is ordered after "2"
+                return strnatcmp($sortBy[$a->getName()], $sortBy[$b->getName()]);
+            });
+
             return $result;
         }
 
         return null;
-
     }
 
-}
+    /**
+     * Return a string to sort the elements by to get them in the same order as they are in the blocks.
+     *
+     * @param string $elementName
+     * @param Tag[] $elements
+     * @return string
+     */
+    private function getElementSortIndex($elementName, $elements)
+    {
+        // "areablock:1.block:2.input" => ["areablock", "1", "block", "2", "input"]
+        $parts = preg_split('/:(\d+)\./', $elementName, -1, PREG_SPLIT_DELIM_CAPTURE);
 
+        $sortIndices = [];
+        $blockName = '';
+
+        for ($i = 1, $count = count($parts); $i < $count; $i += 2) {
+            $blockName .= $parts[$i - 1]; // "areablock"
+            $blockKey = $parts[$i]; // "1"
+
+            $block = $elements[$blockName];
+            if ($block instanceof BlockInterface) {
+                $indices = $block->getData();
+                if ($block instanceof Areablock) {
+                    $indices = array_column($indices, 'key');
+                }
+
+                $index = array_search($blockKey, $indices);
+                if ($index !== false) {
+                    $sortIndices[] = $index;
+                }
+            }
+
+            $blockName .= ":$blockKey."; // "areablock:1."
+        }
+
+        return implode(' ', $sortIndices);
+    }
+}


### PR DESCRIPTION
Orders the document elements by the order they have in blocks, that is the same order the elements/bricks are ordered in admin.

Closes #139.