### PR TITLE
Allow CORS requests

### DIFF
--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -170,6 +170,11 @@ class WebserviceController extends FrontendController
             ];
         }
 
+        header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+        header('Access-Control-Allow-Credentials: true');
+        header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
+        header('Access-Control-Allow-Headers: Origin, Content-Type, X-Auth-Token');
+        
         return new JsonResponse($output);
     }
 

--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -169,9 +169,12 @@ class WebserviceController extends FrontendController
                 ],
             ];
         }
-
-        header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
-        header('Access-Control-Allow-Credentials: true');
+        
+        $origin = '*';
+        if (!empty($_SERVER['HTTP_ORIGIN'])) {
+            $origin = $_SERVER['HTTP_ORIGIN'];
+        }
+        header('Access-Control-Allow-Origin: ' . $origin);
         header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
         header('Access-Control-Allow-Headers: Origin, Content-Type, X-Auth-Token');
         

--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -176,7 +176,7 @@ class WebserviceController extends FrontendController
         }
         header('Access-Control-Allow-Origin: ' . $origin);
         header('Access-Control-Allow-Credentials: true');
-        header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
+        header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
         header('Access-Control-Allow-Headers: Origin, Content-Type, X-Auth-Token');
         
         return new JsonResponse($output);

--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -175,6 +175,7 @@ class WebserviceController extends FrontendController
             $origin = $_SERVER['HTTP_ORIGIN'];
         }
         header('Access-Control-Allow-Origin: ' . $origin);
+        header('Access-Control-Allow-Credentials: true');
         header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
         header('Access-Control-Allow-Headers: Origin, Content-Type, X-Auth-Token');
         


### PR DESCRIPTION
This should help accessing DataHub from e.g. localhost on DEV, but also on PROD when the frontend is hosted under e.g. XXX.com and the backend on YYY.com