### PR TITLE
Fullpath for non Thumbnail Aware Assets

### DIFF
--- a/src/GraphQL/AssetType/AssetType.php
+++ b/src/GraphQL/AssetType/AssetType.php
@@ -21,6 +21,7 @@ use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Resolver;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
 use Pimcore\Model\Asset;
@@ -29,36 +30,40 @@ class AssetType extends ObjectType
 {
     use ServiceTrait;
 
+    /**
+     * @var string
+     */
     protected $fieldname;
 
     /**
-     * AssetType constructor.
      * @param Service $graphQlService
-     * @param AssetMetadataItem $assetMetadataItemType
-     * @param array $config
-     * @param array $context
+     * @param array   $config
+     * @param array   $context
+     *
+     * @throws \Exception
      */
-    public function __construct(Service $graphQlService, $config = ["name" => "asset"], $context = [])
+    public function __construct(Service $graphQlService, $config = ['name' => 'asset'], $context = [])
     {
         $this->setGraphQLService($graphQlService);
         $this->build($config);
         parent::__construct($config);
     }
 
-
     /**
-     * @param array $config
+     * @param $config
+     *
+     * @throws \Exception
      */
     public function build(&$config)
     {
-        $resolver = new \Pimcore\Bundle\DataHubBundle\GraphQL\Resolver\AssetType();
+        $resolver = new Resolver\AssetType();
         $resolver->setGraphQLService($this->getGraphQlService());
 
         $service = $this->getGraphQlService();
-        $assetMetadataItemType = $service->buildAssetType("asset_metadataitem");
+        $assetMetadataItemType = $service->buildAssetType('asset_metadataitem');
 
         $propertyType = $this->getGraphQlService()->buildGeneralType('element_property');
-        $elementResolver = new \Pimcore\Bundle\DataHubBundle\GraphQL\Resolver\Element('asset');
+        $elementResolver = new Resolver\Element('asset');
 
         $config['fields'] = [
             'creationDate' => Type::int(),
@@ -73,36 +78,10 @@ class AssetType extends ObjectType
 
                 ],
                 'resolve' => function($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                    if ($value instanceof ElementDescriptor) {
-                        $image = Asset::getById($value["id"]);
-                        if (!WorkspaceHelper::isAllowed($image, $context['configuration'], 'read')) {
-                            if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                throw new \Exception('not allowed to view asset');
-                            } else {
-                                return null;
-                            }
-                        }
-
-                        if ($image instanceof Asset\Image || $image instanceof Asset\Video) {
-                            if (isset($args["thumbnail"])) {
-                                return $image->getThumbnail($args["thumbnail"], false);
-                            } else {
-                                return $image->getFullPath();
-                            }
-                        }
-                        if ($image instanceof Asset\Document)
-                        {
-                            if (isset($args["thumbnail"])) {
-                                return $image->getImageThumbnail($args["thumbnail"]);
-                            } else {
-                                return $image->getFullPath();
-                            }
-                        }
-                    }
+                    return $this->resolveAssetPath($value, $args, $context, $resolveInfo, false);
                 }
             ],
             'mimetype' => Type::string(),
-
             'modificationDate' => Type::int(),
             'type' => Type::string(),
             'filesize' => Type::int(),
@@ -110,54 +89,75 @@ class AssetType extends ObjectType
                 'type' => Type::string(),
                 'args' => [
                     'thumbnail' => ['type' => Type::string()]
-
                 ],
                 'resolve' => function($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                    if ($value instanceof ElementDescriptor) {
-                        $image = Asset::getById($value["id"]);
-                        if (!WorkspaceHelper::isAllowed($image, $context['configuration'], 'read')) {
-                            if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                throw new \Exception('not allowed to view asset');
-                            } else {
-                                return null;
-                            }
-                        }
-                        if ($image instanceof Asset\Image || $image instanceof Asset\Video) {
-                            if (isset($args["thumbnail"])) {
-                                $thumb = $image->getThumbnail($args['thumbnail'], false);                                
-                                return base64_encode(file_get_contents($thumb->getFileSystemPath()));
-                            } else {
-                                return base64_encode(file_get_contents($image->getFileSystemPath()));
-                            }
-                        }
-                        if ($image instanceof Asset\Document)
-                        {
-                            if (isset($args["thumbnail"])) {
-                                $thumb = $image->getImageThumbnail($args['thumbnail']);
-                                return base64_encode(file_get_contents($thumb->getFileSystemPath()));
-                            } else {
-                                return base64_encode(file_get_contents($image->getFileSystemPath()));
-                            }
-                        }
-                    }
-                    return null;
+                    return $this->resolveAssetPath($value, $args, $context, $resolveInfo, true);
                 }
             ],
             'metadata' => [
                 'type' => Type::listOf($assetMetadataItemType),
-                'resolve' => [$resolver, "resolveMetadata"]
+                'resolve' => [$resolver, 'resolveMetadata']
             ],
             'properties' => [
                 'type' => Type::listOf($propertyType),
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma seperated list of key names'
+                        'description' => 'comma separated list of key names'
                     ]
                 ],
-                'resolve' => [$elementResolver, "resolveProperties"]
+                'resolve' => [$elementResolver, 'resolveProperties']
             ]
         ];
+    }
+
+    /**
+     * @param mixed       $value
+     * @param array       $args
+     * @param array       $context
+     * @param ResolveInfo $resolveInfo
+     * @param bool        $resolveForData
+     *
+     * @return string|null
+     * @throws \Exception
+     */
+    protected function resolveAssetPath($value, $args, $context, ResolveInfo $resolveInfo, bool $resolveForData = false)
+    {
+        if (!$value instanceof ElementDescriptor) {
+            return null;
+        }
+
+        $asset = Asset::getById($value['id']);
+
+        if (!WorkspaceHelper::isAllowed($asset, $context['configuration'], 'read')) {
+            if (PimcoreDataHubBundle::getNotAllowedPolicy() === PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
+                throw new \Exception('not allowed to view asset');
+            } else {
+                return null;
+            }
+        }
+
+        if ($asset instanceof Asset\Image || $asset instanceof Asset\Video) {
+            if ($resolveForData === false) {
+                return isset($args['thumbnail']) ? $asset->getThumbnail($args['thumbnail'], false) : $asset->getFullPath();
+            } else {
+                return isset($args['thumbnail'])
+                    ? base64_encode(file_get_contents($asset->getThumbnail($args['thumbnail'], false)->getFileSystemPath()))
+                    : base64_encode(file_get_contents($asset->getFileSystemPath()));
+            }
+        } elseif ($asset instanceof Asset\Document) {
+            if ($resolveForData === false) {
+                return isset($args['thumbnail']) ? $asset->getImageThumbnail($args['thumbnail']) : $asset->getFullPath();
+            } else {
+                return isset($args['thumbnail'])
+                    ? base64_encode(file_get_contents($asset->getImageThumbnail($args['thumbnail'])->getFileSystemPath()))
+                    : base64_encode(file_get_contents($asset->getFileSystemPath()));
+            }
+        } elseif ($asset instanceof Asset) {
+            return $resolveForData === false ? $asset->getFullPath() : base64_encode(file_get_contents($asset->getFileSystemPath()));
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
This PR:
- will return the full path for asset types beside images/videos like audio. Currently,`fullpath` returns `null` 
- refactors the `AssetType` class to prevent duplicate code