### PR TITLE
fixed faulty import

### DIFF
--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Base.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Base.php
@@ -16,7 +16,7 @@
 namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator;
 
 use GraphQL\Type\Definition\Type;
-use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGeneratorInterface;
+use Pimcore\Bundle\DataHubBundle\GraphQL\QueryFieldConfigGeneratorInterface;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\TypeDefinitionInterface;


### PR DESCRIPTION
When creating a GraphQL API for some object classes in Datahub, we get HTTP 500 responses when we open up fields from an entity in our query schema. Internally, PHP gives 

```PHP Fatal error:  Interface 'Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGeneratorInterface' not found in /var/www/tiemen.pimcore6demo.studioemma.com/versions/wwwroot/vendor/pimcore/data-hub/src/GraphQL/DataObjectQueryFieldConfigGenerator/Base.php on line 26```

Exploring Base.php, I found it to be importing 

```use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGeneratorInterface;```

Whereas the file is called ```QueryFieldConfigGeneratorInterface.php```

Fixing this import to ```use Pimcore\Bundle\DataHubBundle\GraphQL\QueryFieldConfigGeneratorInterface;``` has fixed the issue.
