### PR TITLE
Adding new missing fields to LinkDataType.

### DIFF
--- a/src/GraphQL/DocumentElementType/LinkDataType.php
+++ b/src/GraphQL/DocumentElementType/LinkDataType.php
@@ -102,7 +102,39 @@ class LinkDataType extends ObjectType
                     'target' => [
                         'type' => $anyTargetType,
                         'resolve' => [new Link($this->getGraphQlService()), "resolveTarget"]
-                    ]
+                    ],
+                    'windowTarget' => [ // Target is already in use.
+                        'type' => Type::string(),
+                        'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
+                            if ($value instanceof \Pimcore\Model\Document\Tag\Link) {
+                                return $value->getData() ? $value->getData()["target"] : null;
+                            }
+                        }
+                    ],
+                    'parameters' => [
+                        'type' => Type::string(),
+                        'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
+                            if ($value instanceof \Pimcore\Model\Document\Tag\Link) {
+                                return $value->getData() ? $value->getData()["parameters"] : null;
+                            }
+                        }
+                    ],
+                    'anchor' => [
+                        'type' => Type::string(),
+                        'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
+                            if ($value instanceof \Pimcore\Model\Document\Tag\Link) {
+                                return $value->getData() ? $value->getData()["anchor"] : null;
+                            }
+                        }
+                    ],
+                    'title' => [
+                        'type' => Type::string(),
+                        'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
+                            if ($value instanceof \Pimcore\Model\Document\Tag\Link) {
+                                return $value->getData() ? $value->getData()["title"] : null;
+                            }
+                        }
+                    ],
                 ]
             ];
         parent::__construct($config);


### PR DESCRIPTION
Target is named windowTarget because Target is already in use.