### PR TITLE
Use symfony requests and response objects

### DIFF
--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -89,7 +89,6 @@ class WebserviceController extends FrontendController
         $queryType = new QueryType($service, $localeService, $modelFactory, $this->eventDispatcher, [], $context);
         $mutationType = new MutationType($service, $localeService, $modelFactory, $this->eventDispatcher, [], $context);
 
-
         try {
             $schemaConfig = [
                 'query' => $queryType
@@ -113,8 +112,8 @@ class WebserviceController extends FrontendController
             throw $e;
         }
 
-        $rawInput = file_get_contents('php://input');
-        $input = json_decode($rawInput, true);
+        $input = json_decode($request->getContent(), true);
+
         $query = $input['query'];
         $variableValues = isset($input['variables']) ? $input['variables'] : null;
 
@@ -169,17 +168,18 @@ class WebserviceController extends FrontendController
                 ],
             ];
         }
-        
+
         $origin = '*';
         if (!empty($_SERVER['HTTP_ORIGIN'])) {
             $origin = $_SERVER['HTTP_ORIGIN'];
         }
-        header('Access-Control-Allow-Origin: ' . $origin);
-        header('Access-Control-Allow-Credentials: true');
-        header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-        header('Access-Control-Allow-Headers: Origin, Content-Type, X-Auth-Token');
-        
-        return new JsonResponse($output);
+
+        $response = new JsonResponse($output);
+        $response->headers->set('Access-Control-Allow-Origin', $origin);
+        $response->headers->set('Access-Control-Allow-Credentials', 'true');
+        $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+        $response->headers->set('Access-Control-Allow-Headers', 'Origin, Content-Type, X-Auth-Token');
+        return $response;
     }
 
     /**


### PR DESCRIPTION
While writing some functional tests for my client using Codeception I stumbled upon some behaviour in the `WebserviceController` which makes it almost impossible to write a functional test, without al kind of strange hacks, if even possible.

My setup is the following:
- enabled the `Pimcore\Tests\Helper\Pimcore` codeception module, which can act as an `InnerBrowser` and directly do requests to the Symfony kernel
- Wrote a `GraphQL` module which uses the `Pimcore` module to dispatch GraphQL requests.

The implementation described above expects the Symfony response and request objects to be used. This is good practice anyway as you are not expected to directly access superglobals or headers in a Symfony application as this could cause unwanted side effects.

I have refactored `php:://input` stream to use the request content now. I don't see why we need the raw input stream in this case, but maybe there is a good reason I don't know of.
And headers are set using the response object.

I have also tested in Insomnia (GraphQL client) and still get good responses and headers are identical.
