### PR TITLE
add object folder properties

### DIFF
--- a/src/GraphQL/DataObjectType/ObjectFolderType.php
+++ b/src/GraphQL/DataObjectType/ObjectFolderType.php
@@ -38,7 +38,9 @@ class ObjectFolderType extends FolderType
      */
     public function build(&$config)
     {
+        $propertyType = $this->getGraphQlService()->buildGeneralType('element_property');
         $objectTreeType = $this->getGraphQlService()->buildGeneralType('object_tree');
+
         $resolver = new \Pimcore\Bundle\DataHubBundle\GraphQL\Resolver\Element('object', $this->getGraphQLService());
 
         $config['fields'] = [
@@ -65,6 +67,16 @@ class ObjectFolderType extends FolderType
                     ],
                 ],
                 'resolve' => [$resolver, 'resolveChildren'],
+            ],
+            'properties' => [
+                'type' => Type::listOf($propertyType),
+                'args' => [
+                    'keys' => [
+                        'type' => Type::listOf(Type::string()),
+                        'description' => 'comma separated list of key names'
+                    ]
+                ],
+                'resolve' => [$resolver, "resolveProperties"]
             ],
             '_siblings' => [
                 'type' => Type::listOf($objectTreeType),


### PR DESCRIPTION
```graphql
{
  getObjectFolder(id: 3) {
    fullpath
    properties(keys: ["test","obj"]) {
      ... on property_text {
        name, text
      },
      ... on property_object {
        object {
          ... on object_test {
            test
          }
        }
      }
    }
  }
}
```


```json
{
  "data": {
    "getObjectFolder": {
      "fullpath": "/testtest",
      "properties": [
        {
          "object": {
            "test": "test"
          }
        },
        {
          "name": "test",
          "text": "test"
        }
      ]
    }
  }
}
```