### PR TITLE
Implement Client safe exceptions

### DIFF
--- a/src/GraphQL/AssetType/AssetType.php
+++ b/src/GraphQL/AssetType/AssetType.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Resolver;
@@ -175,7 +176,7 @@ class AssetType extends ObjectType
 
         if (!WorkspaceHelper::isAllowed($asset, $context['configuration'], 'read')) {
             if (PimcoreDataHubBundle::getNotAllowedPolicy() === PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new \Exception('not allowed to view asset');
+                throw new NotAllowedException('not allowed to view asset');
             } else {
                 return null;
             }

--- a/src/GraphQL/ClassTypeDefinitions.php
+++ b/src/GraphQL/ClassTypeDefinitions.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL;
 
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\PimcoreObjectType;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Cache\Runtime;
 use Pimcore\Db;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -66,7 +67,7 @@ class ClassTypeDefinitions
         $className = is_string($class) ? $class : $class->getName();
         $result = self::$definitions[$className];
         if (!$result) {
-            throw new \Exception('type definition ' . $className . ' not found');
+            throw new ClientSafeException('type definition ' . $className . ' not found');
         }
 
         return $result;

--- a/src/GraphQL/ClassificationstoreType/Feature.php
+++ b/src/GraphQL/ClassificationstoreType/Feature.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\ClassificationstoreType;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FeatureDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
@@ -67,7 +68,7 @@ class Feature extends UnionType implements ContainerAwareInterface
     public function resolveType($element, $context, ResolveInfo $info)
     {
         if (!$element instanceof FeatureDescriptor) {
-            throw new \Exception("expected feature descriptor");
+            throw new ClientSafeException("expected feature descriptor");
         }
 
         $type = $element->getType();

--- a/src/GraphQL/DataObjectInputProcessor/IfEmptyOperator.php
+++ b/src/GraphQL/DataObjectInputProcessor/IfEmptyOperator.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectInputProcessor;
 
 
 use GraphQL\Type\Definition\ResolveInfo;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Model\DataObject\Concrete;
 
 class IfEmptyOperator extends BaseOperator
@@ -53,26 +54,25 @@ class IfEmptyOperator extends BaseOperator
         }
 
         if (count($children) !== 1) {
-            throw new \UnexpectedValueException("Only one child allowed");
+            throw new ClientSafeException("Only one child allowed");
         }
 
         $firstChild = $children[0];
 
         if ($firstChild['isOperator']) {
-            throw new \Exception("Not allowed");
-        } else {
+            throw new ClientSafeException("First child should not be an operator");
+        }
 
-            $key = $firstChild["attributes"]["attribute"];
-            $fieldDefinition = $this->getGraphQlService()->getObjectFieldHelper()->getFieldDefinitionFromKey($class, $key);
-            if ($fieldDefinition) {
-                $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($firstChild);
-                $valueFromChild = $valueResolver->getLabeledValue($object, null);
+        $key = $firstChild["attributes"]["attribute"];
+        $fieldDefinition = $this->getGraphQlService()->getObjectFieldHelper()->getFieldDefinitionFromKey($class, $key);
+        if ($fieldDefinition) {
+            $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($firstChild);
+            $valueFromChild = $valueResolver->getLabeledValue($object, null);
 
-                if (!$valueFromChild || $fieldDefinition->isEmpty($valueFromChild->value)) {
-                    $parentProcessor = $this->getParentProcessor($this->nodeDef, $class);
-                    if ($parentProcessor) {
-                        call_user_func_array($parentProcessor, [$object, $newValue, $args, $context, $info]);
-                    }
+            if (!$valueFromChild || $fieldDefinition->isEmpty($valueFromChild->value)) {
+                $parentProcessor = $this->getParentProcessor($this->nodeDef, $class);
+                if ($parentProcessor) {
+                    call_user_func_array($parentProcessor, [$object, $newValue, $args, $context, $info]);
                 }
             }
         }

--- a/src/GraphQL/DataObjectInputProcessor/Image.php
+++ b/src/GraphQL/DataObjectInputProcessor/Image.php
@@ -15,7 +15,9 @@
 
 namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectInputProcessor;
 
+use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Model\Asset;
@@ -38,7 +40,7 @@ class Image extends Base
 
         if(!array_key_exists('id',$newValue)) {
             if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new \Exception("Field {$attribute}.id was not provided.");
+                throw new UserError("Field {$attribute}.id was not provided.");
             }
             return null;
         }

--- a/src/GraphQL/DataObjectInputProcessor/ManyToManyObjectRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToManyObjectRelation.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectInputProcessor;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Model\DataObject\Concrete;
 
@@ -39,7 +40,7 @@ class ManyToManyObjectRelation extends Base
             if (is_array($newValue)) {
                 foreach ($newValue as $newValueItemKey => $newValueItemValue) {
                     if (isset($newValueItemValue["type"]) && $newValueItemValue["type"] !== 'object') {
-                        throw new \Exception("expected object type");
+                        throw new ClientSafeException("expected object type");
                     }
 
                     $element = \Pimcore\Model\Element\Service::getElementById('object', $newValueItemValue["id"]);

--- a/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectInputProcessor;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Model\DataObject\Concrete;
 
@@ -39,11 +40,11 @@ class ManyToManyRelation extends Base
             if (is_array($newValue)) {
                 foreach ($newValue as $newValueItemKey => $newValueItemValue) {
                     if (!isset($newValueItemValue["type"])) {
-                        throw new \Exception("type expected");
+                        throw new ClientSafeException("type expected");
                     }
 
                     if (!isset($newValueItemValue["id"])) {
-                        throw new \Exception("ID expected");
+                        throw new ClientSafeException("ID expected");
                     }
 
                     $element = \Pimcore\Model\Element\Service::getElementById($newValueItemValue["type"], $newValueItemValue["id"]);

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/AssetBase.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/AssetBase.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FieldcollectionDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
@@ -83,7 +84,7 @@ class AssetBase
 
         if (!WorkspaceHelper::isAllowed($assetElement, $context['configuration'], 'read')) {
             if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new \Exception('not allowed to view ' . $asset->getFullPath());
+                throw new NotAllowedException('not allowed to view ' . $asset->getFullPath());
             } else {
                 return null;
             }

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Hotspotimage.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Hotspotimage.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -87,7 +88,7 @@ class Hotspotimage
             $image = $container->getImage();
             if ($image instanceof Asset) {
                 if (!WorkspaceHelper::isAllowed($image, $context['configuration'], 'read')) {
-                    throw new \Exception('permission denied. check your workspace settings');
+                    throw new NotAllowedException('permission denied. check your workspace settings');
                 }
 
                 $data = new ElementDescriptor($image);

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Href.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Href.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -77,7 +78,7 @@ class Href
         if ($relation instanceof ElementInterface) {
             if (!WorkspaceHelper::isAllowed($relation, $context['configuration'], 'read')) {
                 if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                    throw new \Exception('not allowed to view ' . $relation->getFullPath());
+                    throw new NotAllowedException('not allowed to view ' . $relation->getFullPath());
                 } else {
                     return null;
                 }

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ImageGallery.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ImageGallery.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service as GraphQlService;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -95,7 +96,7 @@ class ImageGallery
 
                 if ($image instanceof Asset) {
                     if (!WorkspaceHelper::isAllowed($image, $context['configuration'], 'read')) {
-                        throw new \Exception('permission denied. check your workspace settings');
+                        throw new NotAllowedException('permission denied. check your workspace settings');
                     }
 
                     $data = new ElementDescriptor($image);

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Multihref.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Multihref.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -76,7 +77,7 @@ class Multihref
             foreach ($relations as $relation) {
                 if (!WorkspaceHelper::isAllowed($relation, $context['configuration'], 'read')) {
                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                        throw new \Exception('not allowed to view ' . $relation->getFullPath());
+                        throw new NotAllowedException('not allowed to view ' . $relation->getFullPath());
                     } else {
                         continue;
                     }

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/MultihrefMetadata.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/MultihrefMetadata.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -76,7 +77,7 @@ class MultihrefMetadata
                 $element = $relation->getElement();
                 if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                        throw new \Exception('not allowed to view ' . $relation->getFullPath());
+                        throw new NotAllowedException('not allowed to view ' . $relation->getFullPath());
                     } else {
                         continue;
                     }

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Objects.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/Objects.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -77,7 +78,7 @@ class Objects
             foreach ($relations as $relation) {
                 if (!WorkspaceHelper::isAllowed($relation, $context['configuration'], 'read')) {
                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                        throw new \Exception('not allowed to view ' . $relation->getFullPath());
+                        throw new NotAllowedException('not allowed to view ' . $relation->getFullPath());
                     } else {
                         continue;
                     }

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ObjectsMetadata.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ObjectsMetadata.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -76,7 +77,7 @@ class ObjectsMetadata
                 $element = $relation->getElement();
                 if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                        throw new \Exception('not allowed to view ' . $element->getFullPath());
+                        throw new NotAllowedException('not allowed to view ' . $element->getFullPath());
                     } else {
                         continue;
                     }

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ReverseManyToManyObjects.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ReverseManyToManyObjects.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerat
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -82,7 +83,7 @@ class ReverseManyToManyObjects
                 if ($relation) {
                     if (!WorkspaceHelper::isAllowed($relation, $context['configuration'], 'read')) {
                         if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                            throw new \Exception('not allowed to view ' . $relation->getFullPath());
+                            throw new NotAllowedException('not allowed to view ' . $relation->getFullPath());
                         } else {
                             continue;
                         }

--- a/src/GraphQL/Exception/ClientSafeException.php
+++ b/src/GraphQL/Exception/ClientSafeException.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\GraphQL\Exception;
+
+use GraphQL\Error\ClientAware;
+
+class ClientSafeException extends \Exception implements ClientAware
+{
+    /**
+     * @return bool
+     */
+    public function isClientSafe()
+    {
+        return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCategory()
+    {
+        return 'pimcore.datahub';
+    }
+}

--- a/src/GraphQL/Exception/NotAllowedException.php
+++ b/src/GraphQL/Exception/NotAllowedException.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\GraphQL\Exception;
+
+
+class NotAllowedException extends ClientSafeException
+{
+
+}

--- a/src/GraphQL/FieldHelper/DataObjectFieldHelper.php
+++ b/src/GraphQL/FieldHelper/DataObjectFieldHelper.php
@@ -19,6 +19,7 @@ use GraphQL\Language\AST\FieldNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGeneratorInterface;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\File;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -206,7 +207,7 @@ class DataObjectFieldHelper extends AbstractFieldHelper
             case 'mutation':
                 return $this->getGraphQlService()->supportsDataObjectMutationDataType($typeName);
             default:
-                throw new \Exception("unknown operation type");
+                throw new ClientSafeException("unknown operation type " . $typeName);
         }
     }
 

--- a/src/GraphQL/PropertyType/AssetFolderType.php
+++ b/src/GraphQL/PropertyType/AssetFolderType.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
@@ -75,7 +76,7 @@ class AssetFolderType extends ObjectType
                         if ($element) {
                             if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                                 if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                    throw new \Exception('not allowed to view document');
+                                    throw new NotAllowedException('not allowed to view document');
                                 } else {
                                     return null;
                                 }

--- a/src/GraphQL/PropertyType/AssetType.php
+++ b/src/GraphQL/PropertyType/AssetType.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
@@ -75,7 +76,7 @@ class AssetType extends ObjectType
                             if ($element) {
                                 if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                        throw new \Exception('not allowed to view object');
+                                        throw new NotAllowedException('not allowed to view object');
                                     } else {
                                         return null;
                                     }

--- a/src/GraphQL/PropertyType/DataObjectType.php
+++ b/src/GraphQL/PropertyType/DataObjectType.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
@@ -74,7 +75,7 @@ class DataObjectType extends ObjectType
                             if ($element) {
                                 if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                        throw new \Exception('not allowed to view object');
+                                        throw new NotAllowedException('not allowed to view object');
                                     } else {
                                         return null;
                                     }

--- a/src/GraphQL/PropertyType/DocumentFolderType.php
+++ b/src/GraphQL/PropertyType/DocumentFolderType.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
@@ -74,7 +75,7 @@ class DocumentFolderType extends ObjectType
                         if ($element) {
                             if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                                 if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                    throw new \Exception('not allowed to view document');
+                                    throw new NotAllowedException('not allowed to view document');
                                 } else {
                                     return null;
                                 }

--- a/src/GraphQL/PropertyType/DocumentType.php
+++ b/src/GraphQL/PropertyType/DocumentType.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
@@ -74,7 +75,7 @@ class DocumentType extends ObjectType
                         if ($element) {
                             if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                                 if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                    throw new \Exception('not allowed to view document');
+                                    throw new NotAllowedException('not allowed to view document');
                                 } else {
                                     return null;
                                 }

--- a/src/GraphQL/PropertyType/ElementPropertyType.php
+++ b/src/GraphQL/PropertyType/ElementPropertyType.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\PropertyType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
 use Pimcore\Bundle\DataHubBundle\GraphQL\DocumentType\DocumentFolderType;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\TypeInterface\Property;
@@ -155,7 +156,7 @@ class ElementPropertyType extends UnionType
                     }
                 }
                 default:
-                    throw new \Exception("unkown property type: " . $type);
+                    throw new ClientSafeException("unkown property type: " . $type);
             }
         }
         return null;

--- a/src/GraphQL/PropertyType/HotspotMetadataType.php
+++ b/src/GraphQL/PropertyType/HotspotMetadataType.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\PropertyType;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\TypeInterface\Property;
@@ -105,7 +106,7 @@ class HotspotMetadataType extends UnionType
                     return $this->objectType;
                 }
                 default:
-                    throw new \Exception("unkown metadata type: " . $type);
+                    throw new ClientSafeException("unkown metadata type: " . $type);
             }
         }
         return null;

--- a/src/GraphQL/PropertyType/ObjectFolderType.php
+++ b/src/GraphQL/PropertyType/ObjectFolderType.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
@@ -75,7 +76,7 @@ class ObjectFolderType extends ObjectType
                         if ($element) {
                             if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
                                 if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                                    throw new \Exception('not allowed to view document');
+                                    throw new NotAllowedException('not allowed to view document');
                                 } else {
                                     return null;
                                 }

--- a/src/GraphQL/Resolver/Element.php
+++ b/src/GraphQL/Resolver/Element.php
@@ -18,6 +18,8 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\Resolver;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FieldHelper\AbstractFieldHelper;
@@ -46,18 +48,20 @@ class Element
     }
 
     /**
-     * @param array $value
-     * @param array $args
-     * @param array $context
+     * @param array            $value
+     * @param array            $args
+     * @param array            $context
      * @param ResolveInfo|null $resolveInfo
+     * @return array|Property[]|null
+     * @throws ClientSafeException
      */
-    public function resolveProperties($value = null, $args = [], $context, ResolveInfo $resolveInfo = null)
+    public function resolveProperties(array $value = null, array $args = [], array $context, ResolveInfo $resolveInfo = null)
     {
         $elementId = $value["id"];
         $element = ElementService::getElementById($this->elementType, $elementId);
 
         if (!$element) {
-            throw new \Exception("element " . $this->elementType . " " . $elementId . " not found");
+            throw new ClientSafeException("element " . $this->elementType . " " . $elementId . " not found");
         }
 
         if (isset($args['keys'])) {
@@ -177,7 +181,7 @@ class Element
         // Check Workspace permissions
         if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read')) {
             if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new \Exception('not allowed to view ' . $element->getFullPath());
+                throw new NotAllowedException('not allowed to view ' . $element->getFullPath());
             } else {
                 return null;
             }

--- a/src/GraphQL/Resolver/HotspotType.php
+++ b/src/GraphQL/Resolver/HotspotType.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\Resolver;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -47,7 +48,7 @@ class HotspotType
             $image = Asset::getById($value["id"]);
             if (!WorkspaceHelper::isAllowed($image, $context['configuration'], 'read')) {
                 if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                    throw new \Exception('not allowed to view asset');
+                    throw new NotAllowedException('not allowed to view asset');
                 } else {
                     return null;
                 }

--- a/src/GraphQL/Resolver/QueryType.php
+++ b/src/GraphQL/Resolver/QueryType.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\Resolver;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\Configuration;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Helper;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\PermissionInfoTrait;
@@ -68,7 +69,7 @@ class QueryType
      * @param array $context
      * @param ResolveInfo|null $resolveInfo
      * @return array
-     * @throws \Exception
+     * @throws ClientSafeException
      */
     public function resolveFolderGetter($value = null, $args = [], $context, ResolveInfo $resolveInfo = null, $elementType)
     {
@@ -92,7 +93,7 @@ class QueryType
 
         if (!WorkspaceHelper::isAllowed($element, $context['configuration'], 'read') && !$this->omitPermissionCheck) {
             if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new \Exception('not allowed to view element ' . Service::getElementType($element));
+                throw new ClientSafeException('not allowed to view element ' . Service::getElementType($element));
             } else {
                 return null;
             }
@@ -112,7 +113,7 @@ class QueryType
      * @param array $context
      * @param ResolveInfo|null $resolveInfo
      * @return array
-     * @throws \Exception
+     * @throws ClientSafeException
      */
     public function resolveAssetFolderGetter($value = null, $args = [], $context, ResolveInfo $resolveInfo = null) {
         return $this->resolveFolderGetter($value, $args, $context, $resolveInfo, "asset");
@@ -125,7 +126,7 @@ class QueryType
      * @param array $context
      * @param ResolveInfo|null $resolveInfo
      * @return array
-     * @throws \Exception
+     * @throws ClientSafeException
      */
     public function resolveDocumentFolderGetter($value = null, $args = [], $context, ResolveInfo $resolveInfo = null) {
         return $this->resolveFolderGetter($value, $args, $context, $resolveInfo, "document");
@@ -137,7 +138,7 @@ class QueryType
      * @param array $context
      * @param ResolveInfo|null $resolveInfo
      * @return array
-     * @throws \Exception
+     * @throws ClientSafeException
      */
     public function resolveObjectFolderGetter($value = null, $args = [], $context, ResolveInfo $resolveInfo = null) {
         return $this->resolveFolderGetter($value, $args, $context, $resolveInfo, "object");
@@ -149,7 +150,7 @@ class QueryType
      * @param array $context
      * @param ResolveInfo|null $resolveInfo
      * @return array
-     * @throws \Exception
+     * @throws ClientSafeException
      */
     public function resolveDocumentGetter($value = null, $args = [], $context, ResolveInfo $resolveInfo = null)
     {
@@ -171,7 +172,7 @@ class QueryType
 
         if (!WorkspaceHelper::isAllowed($documentElement, $context['configuration'], 'read') && !$this->omitPermissionCheck ) {
             if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new \Exception('not allowed to view document ' . $documentElement->getFullPath());
+                throw new ClientSafeException('not allowed to view document ' . $documentElement->getFullPath());
             } else {
                 return null;
             }
@@ -191,7 +192,7 @@ class QueryType
      * @param array $context
      * @param ResolveInfo|null $resolveInfo
      * @return array
-     * @throws \Exception
+     * @throws ClientSafeException
      */
     public function resolveAssetGetter($value = null, $args = [], $context, ResolveInfo $resolveInfo = null)
     {
@@ -206,7 +207,7 @@ class QueryType
 
         if (!WorkspaceHelper::isAllowed($assetElement, $context['configuration'], 'read') && !$this->omitPermissionCheck ) {
             if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new \Exception('not allowed to view asset ' . $assetElement->getFullPath());
+                throw new ClientSafeException('not allowed to view asset ' . $assetElement->getFullPath());
             } else {
                 return null;
             }
@@ -224,7 +225,7 @@ class QueryType
      * @param array $context
      * @param ResolveInfo|null $resolveInfo
      * @return array
-     * @throws \Exception
+     * @throws ClientSafeException
      */
     public function resolveObjectGetter($value = null, $args = [], $context, ResolveInfo $resolveInfo = null)
     {
@@ -263,12 +264,12 @@ class QueryType
         $objectList->setUnpublished(1);
         $objectList = $objectList->load();
         if (!$objectList) {
-            throw new \Exception('object with ID ' . $args["id"] . ' not found');
+            throw new ClientSafeException('object with ID ' . $args["id"] . ' not found');
         }
         $object = $objectList[0];
 
         if (!WorkspaceHelper::isAllowed($object, $configuration, 'read') && !$this->omitPermissionCheck) {
-            throw new \Exception('permission denied. check your workspace settings');
+            throw new ClientSafeException('permission denied. check your workspace settings');
         }
 
         $data = new ElementDescriptor($object);
@@ -378,7 +379,7 @@ class QueryType
         if (isset($args['filter'])) {
             $filter = json_decode($args['filter'], false);
             if (!$filter) {
-                throw new \Exception('unable to decode filter');
+                throw new ClientSafeException('unable to decode filter');
             }
             $filterCondition = Helper::buildSqlCondition($filter);
             $conditionParts[] = $filterCondition;

--- a/src/GraphQL/Resolver/Video.php
+++ b/src/GraphQL/Resolver/Video.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\Resolver;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
@@ -92,7 +93,7 @@ class Video
             if ($asset instanceof Image) {
                 if (!WorkspaceHelper::isAllowed($asset, $context['configuration'], 'read')) {
                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                        throw new \Exception('not allowed to view video');
+                        throw new NotAllowedException('not allowed to view video');
                     } else {
                         return null;
                     }
@@ -124,7 +125,7 @@ class Video
             if ($value->getType() == "asset" && $value->getData() instanceof \Pimcore\Model\Asset\Video) {
                 if (!WorkspaceHelper::isAllowed($value->getData(), $context['configuration'], 'read')) {
                     if (PimcoreDataHubBundle::getNotAllowedPolicy() == PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                        throw new \Exception('not allowed to view video');
+                        throw new NotAllowedException('not allowed to view video');
                     } else {
                         return null;
                     }

--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Pimcore\Bundle\DataHubBundle\Configuration;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FieldHelper\AssetFieldHelper;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FieldHelper\DataObjectFieldHelper;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FieldHelper\DocumentFieldHelper;
@@ -663,7 +664,7 @@ class Service
         if (isset($this->assetDataTypes[$typename])) {
             return $this->assetDataTypes[$typename];
         }
-        throw new \Exception("unknown asset type: " . $typename);
+        throw new ClientSafeException("unknown asset type: " . $typename);
     }
 
 
@@ -677,7 +678,7 @@ class Service
         if (isset($this->classificationStoreDataTypes[$typename])) {
             return $this->classificationStoreDataTypes[$typename];
         }
-        throw new \Exception("unknown classificationstore type: " . $typename);
+        throw new ClientSafeException("unknown classificationstore type: " . $typename);
     }
 
 
@@ -691,7 +692,7 @@ class Service
         if (isset($this->dataObjectDataTypes[$typename])) {
             return $this->dataObjectDataTypes[$typename];
         }
-        throw new \Exception("unknown dataobject type: " . $typename);
+        throw new ClientSafeException("unknown dataobject type: " . $typename);
     }
 
 
@@ -705,7 +706,7 @@ class Service
         if (isset($this->documentDataTypes[$typename])) {
             return $this->documentDataTypes[$typename];
         }
-        throw new \Exception("unknown document type: " . $typename);
+        throw new ClientSafeException("unknown document type: " . $typename);
     }
 
     /**
@@ -718,7 +719,7 @@ class Service
         if (isset($this->propertyDataTypes[$typename])) {
             return $this->propertyDataTypes[$typename];
         }
-        throw new \Exception("unknown property type: " . $typename);
+        throw new ClientSafeException("unknown property type: " . $typename);
     }
 
 


### PR DESCRIPTION
Here is a POC for the client safe exception as proposed in https://github.com/pimcore/data-hub/issues/194.
I only changed all exceptions which were thrown in `QueryType` for now. We can further refactor some other common cases which messages are perfectly safe and fine to show to the client.

Previously the error looked like this:

```
{
  "errors": [
    {
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      },
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "getProduct"
      ]
    }
  ],
  "data": {
    "getProduct": null
  }
}
```

In the new implementation the error message looks like this:

```
{
  "errors": [
    {
      "message": "object with ID 12 not found",
      "extensions": {
        "category": "pimcore.datahub"
      },
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "getProduct"
      ]
    }
  ],
  "data": {
    "getProduct": null
  }
}
```

When you have pimcore debug mode of the response has the following structure:

```
{
  "errors": [
    {
      "message": "object with ID 12 not found"
    }
  ]
}
```

Previously 

```
{
  "errors": [
    {
      "message": "Internal server error"
    }
  ]
}
```

Thoughts?