### PR TITLE
add new post build events to mutation and query type config build

### DIFF
--- a/doc/graphl/Events.md
+++ b/doc/graphl/Events.md
@@ -90,7 +90,7 @@ class GraphqlListener implements EventSubscriberInterface
     }
 
     /**
-     * @param ExecutorEvent $event
+     * @param MutationTypeEvent $event
      */
     public function onMutationPreBuild(MutationTypeEvent $event)
     {
@@ -99,7 +99,7 @@ class GraphqlListener implements EventSubscriberInterface
     }
 
     /**
-     * @param ExecutorResultEvent $event
+     * @param QueryTypeEvent $event
      */
     public function onQueryPreBuild(QueryTypeEvent $event)
     {
@@ -110,7 +110,58 @@ class GraphqlListener implements EventSubscriberInterface
 
 ```
 
-#### Example 3: Add custom query conditions to object listing
+#### Example 3: Add custom arguments to existing types
+```php
+<?php
+
+namespace AppBundle\EventListener;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\MutationEvents;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\MutationTypeEvent;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\QueryTypeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use GraphQL\Type\Definition\Type;
+
+class GraphqlListener implements EventSubscriberInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            MutationEvents::POST_BUILD => 'onMutationPostBuild',
+            QueryEvents::POST_BUILD => 'onQueryPostBuild'
+        ];
+    }
+
+    /**
+     * @param MutationTypeEvent $event
+     */
+    public function onMutationPostBuild(MutationTypeEvent $event)
+    {
+        $config = $event->getConfig();
+        $config['fields']['getProductListing']['args']['foo'] = [
+            'type'  => Type::boolean()
+        ];
+        $event->setConfig($config);
+    }
+
+    /**
+     * @param QueryTypeEvent $event
+     */
+    public function onQueryPostBuild(QueryTypeEvent $event)
+    {
+        $config = $event->getConfig();
+        $config['fields']['getProductListing']['args']['foo'] = [
+            'type'  => Type::boolean()
+        ];
+        $event->setConfig($config);
+    }
+}
+
+```
+
+#### Example 4: Add custom query conditions to object listing
 
 - For global SQL conditions also [General Settings](https://github.com/pimcore/data-hub/blob/master/doc/graphl/General.md#general-settings)
 - For simple filter conditions also see [Filtering](https://github.com/pimcore/data-hub/blob/master/doc/graphl/Filtering.md#request)

--- a/src/Event/GraphQL/MutationEvents.php
+++ b/src/Event/GraphQL/MutationEvents.php
@@ -22,4 +22,11 @@ final class MutationEvents
      * @var string
      */
     const PRE_BUILD = 'pimcore.datahub.graphql.mutation.preBuild';
+
+    /**
+     * @Event("Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\MutationTypeEvent")
+     *
+     * @var string
+     */
+    const POST_BUILD = 'pimcore.datahub.graphql.mutation.postBuild';
 }

--- a/src/Event/GraphQL/QueryEvents.php
+++ b/src/Event/GraphQL/QueryEvents.php
@@ -22,4 +22,11 @@ final class QueryEvents
      * @var string
      */
     const PRE_BUILD = 'pimcore.datahub.graphql.query.preBuild';
+
+    /**
+     * @Event("Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\QueryTypeEvent")
+     *
+     * @var string
+     */
+    const POST_BUILD = 'pimcore.datahub.graphql.query.postBuild';
 }

--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -116,6 +116,12 @@ class MutationType extends ObjectType
         $this->buildDeleteFolderMutation("asset", $config, $context);
         $this->buildDeleteFolderMutation("document", $config, $context);
         $this->buildDeleteFolderMutation("object", $config, $context);
+
+        $event->setConfig($config);
+        $event->setContext($context);
+        $this->eventDispatcher->dispatch(MutationEvents::POST_BUILD, $event);
+        $config = $event->getConfig();
+
         if (isset($config["fields"]) && count($config["fields"]) > 1) {
             ksort($config["fields"]);
         }

--- a/src/GraphQL/Query/QueryType.php
+++ b/src/GraphQL/Query/QueryType.php
@@ -301,5 +301,10 @@ class QueryType extends ObjectType
         $this->buildFolderQueries("asset", $config, $context);
         $this->buildFolderQueries("document", $config, $context);
         $this->buildFolderQueries("object", $config, $context);
+
+        $event->setConfig($config);
+        $event->setContext($context);
+        $this->eventDispatcher->dispatch(QueryEvents::POST_BUILD, $event);
+        $config = $event->getConfig();
     }
 }


### PR DESCRIPTION
as discussed in #207 the new events in this PR provide the ability to alter the schema configuration before actually building the schema. E.g. for adding custom arguments to existing types (which can be particularly useful with the new feature of #213 )