### PR TITLE
Add resolutions to AssetType

### DIFF
--- a/doc/graphl/querysamples/Sample_GetAsset.md
+++ b/doc/graphl/querysamples/Sample_GetAsset.md
@@ -19,7 +19,19 @@ Note that for the fullpath and the base64 encoded data you can specify a thumbna
     assetThumb: fullpath(thumbnail: "exampleCover")
     # thumbnail URL for content config
     assetThumb2: fullpath(thumbnail: "content")
-    srcset(thumbnail: "content")
+    resolutions(thumbnail: "content", types: [2,5]) {
+        resolution
+        url
+    }
+    srcset(thumbnail: "content") {
+        url
+        descriptor
+        # if types is not defined, then default resolutions @2x will be returned
+        resolutions(types: [2,5]) {
+            url
+            resolution
+        }
+    }
     type
     mimetype
     # original file size
@@ -44,10 +56,30 @@ Note that for the fullpath and the base64 encoded data you can specify a thumbna
               "fullpath": "/Car%20Images/jaguar/auto-automobile-automotive-192499.jpg",
               "assetThumb": "/Car%20Images/jaguar/image-thumb__4__exampleCover/auto-automobile-automotive-192499.webp",
               "assetThumb2": "/Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499.webp",
+              "resolutions": [
+                {
+                  "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@2x.webp",
+                  "resolution": 2
+                },
+                {
+                  "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@5x.webp",
+                  "resolution": 5
+                }
+              ]
               "srcset": [
                 {
                   "descriptor": "768w",
                   "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w.webp"
+                  "resolutions": [
+                    {
+                      "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@2x.webp",
+                      "resolution": 2
+                    },
+                    {
+                      "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@5x.webp",
+                      "resolution": 5
+                    }
+                  ]
                 }
               ],
               "type": "image",

--- a/src/GraphQL/AssetType/AssetType.php
+++ b/src/GraphQL/AssetType/AssetType.php
@@ -16,16 +16,10 @@
 namespace Pimcore\Bundle\DataHubBundle\GraphQL\AssetType;
 
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
-use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
-use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\NotAllowedException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Resolver;
-use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
-use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
-use Pimcore\Model\Asset;
 
 class AssetType extends ObjectType
 {
@@ -38,8 +32,8 @@ class AssetType extends ObjectType
 
     /**
      * @param Service $graphQlService
-     * @param array   $config
-     * @param array   $context
+     * @param array $config
+     * @param array $context
      *
      * @throws \Exception
      */
@@ -67,9 +61,24 @@ class AssetType extends ObjectType
         $propertyType = $this->getGraphQlService()->buildGeneralType('element_property');
         $elementResolver = new Resolver\Element('asset', $this->getGraphQlService());
 
+        $resolutionsType = Type::listOf(new ObjectType([
+            'name' => 'resolutions',
+            'fields' => [
+                'url' => Type::string(),
+                'resolution' => Type::int(),
+            ],
+        ]));
+        $resolutionsArgumentsType = [
+            'type' => Type::listOf(Type::int()),
+            'description' => 'List of resolution types [2, 5, ...]',
+            'defaultValue' => [2]
+        ];
+
+
         $config['fields'] = [
             'creationDate' => Type::int(),
-            'id' => ['name' => 'id',
+            'id' => [
+                'name' => 'id',
                 'type' => Type::id(),
             ],
             'filename' => Type::string(),
@@ -77,45 +86,36 @@ class AssetType extends ObjectType
                 'type' => Type::string(),
                 'args' => [
                     'thumbnail' => ['type' => Type::string()]
-
                 ],
-                'resolve' => function($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                    return $this->resolveAssetPath($value, $args, $context, $resolveInfo, false);
-                }
+                'resolve' => [$resolver, 'resolvePath'],
+            ],
+            'resolutions' => [
+                'type' => $resolutionsType,
+                'args' => [
+                    'thumbnail' => ['type' => Type::nonNull(Type::string())],
+                    'types' => $resolutionsArgumentsType
+                ],
+                'resolve' => [$resolver, 'resolveResolutions'],
             ],
             'srcset' => [
-                'type' => Type::listOf(new \GraphQL\Type\Definition\ObjectType([
-                    'name'  => 'srcset',
+                'type' => Type::listOf(new ObjectType([
+                    'name' => 'srcset',
                     'fields' => [
                         'descriptor' => Type::string(),
                         'url' => Type::string(),
+                        'resolutions' => [
+                            'type' => $resolutionsType,
+                            'args' => [
+                                'types' => $resolutionsArgumentsType,
+                            ],
+                            'resolve' => [$resolver, 'resolveResolutions'],
+                        ],
                     ]
                 ])),
                 'args' => [
-                    'thumbnail' => ['type' => Type::nonNull(Type::string())]
-
+                    'thumbnail' => ['type' => Type::nonNull(Type::string())],
                 ],
-                'resolve' => function($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                    $asset = $this->getAssetFromValue($value, $context);
-
-                    if ($asset instanceof Asset\Image) {
-                        $mediaQueries = [];
-                        $thumbnail = $asset->getThumbnail($args['thumbnail'], false);
-                        $thumbnailConfig = $asset->getThumbnailConfig($args['thumbnail']);
-                        if (
-                            $thumbnailConfig
-                        ) {
-                            foreach ($thumbnailConfig->getMedias() as $key => $val) {
-                                $mediaQueries[] = [
-                                    'descriptor' => $key,
-                                    'url' => $thumbnail->getMedia($key),
-                                ];
-                            }
-                        }
-                        return $mediaQueries;
-                    }
-                    return null;
-                }
+                'resolve' => [$resolver, 'resolveSrcSet'],
             ],
             'mimetype' => Type::string(),
             'modificationDate' => Type::int(),
@@ -126,9 +126,7 @@ class AssetType extends ObjectType
                 'args' => [
                     'thumbnail' => ['type' => Type::string()]
                 ],
-                'resolve' => function($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                    return $this->resolveAssetPath($value, $args, $context, $resolveInfo, true);
-                }
+                'resolve' => [$resolver, 'resolveData'],
             ],
             'metadata' => [
                 'type' => Type::listOf($assetMetadataItemType),
@@ -157,69 +155,6 @@ class AssetType extends ObjectType
                 'resolve' => [$elementResolver, "resolveSiblings"],
             ],
         ];
-    }
-
-    /**
-     * @param mixed       $value
-     * @param array       $context
-     *
-     * @return Asset|null
-     * @throws \Exception
-     */
-    protected function getAssetFromValue($value, $context)
-    {
-        if (!$value instanceof ElementDescriptor) {
-            return null;
-        }
-
-        $asset = Asset::getById($value['id']);
-
-        if (!WorkspaceHelper::isAllowed($asset, $context['configuration'], 'read')) {
-            if (PimcoreDataHubBundle::getNotAllowedPolicy() === PimcoreDataHubBundle::NOT_ALLOWED_POLICY_EXCEPTION) {
-                throw new NotAllowedException('not allowed to view asset');
-            } else {
-                return null;
-            }
-        }
-
-        return $asset;
-    }
-
-    /**
-     * @param mixed       $value
-     * @param array       $args
-     * @param array       $context
-     * @param ResolveInfo $resolveInfo
-     * @param bool        $resolveForData
-     *
-     * @return string|null
-     * @throws \Exception
-     */
-    protected function resolveAssetPath($value, $args, $context, ResolveInfo $resolveInfo, bool $resolveForData = false)
-    {
-        $asset = $this->getAssetFromValue($value, $context);
-
-        if ($asset instanceof Asset\Image || $asset instanceof Asset\Video) {
-            if ($resolveForData === false) {
-                return isset($args['thumbnail']) ? $asset->getThumbnail($args['thumbnail'], false) : $asset->getFullPath();
-            } else {
-                return isset($args['thumbnail'])
-                    ? base64_encode(file_get_contents($asset->getThumbnail($args['thumbnail'], false)->getFileSystemPath()))
-                    : base64_encode(file_get_contents($asset->getFileSystemPath()));
-            }
-        } elseif ($asset instanceof Asset\Document) {
-            if ($resolveForData === false) {
-                return isset($args['thumbnail']) ? $asset->getImageThumbnail($args['thumbnail']) : $asset->getFullPath();
-            } else {
-                return isset($args['thumbnail'])
-                    ? base64_encode(file_get_contents($asset->getImageThumbnail($args['thumbnail'])->getFileSystemPath()))
-                    : base64_encode(file_get_contents($asset->getFileSystemPath()));
-            }
-        } elseif ($asset instanceof Asset) {
-            return $resolveForData === false ? $asset->getFullPath() : base64_encode(file_get_contents($asset->getFileSystemPath()));
-        }
-
-        return null;
     }
 
     /**


### PR DESCRIPTION
Adds new field "resolutions" to Assets and the "srcset" field.

![Screenshot_1](https://user-images.githubusercontent.com/16953779/81295705-1f5b4200-9071-11ea-9181-2f2163cf9dd4.png)

- Types argument is optional (default: 2)
- Types argument can be a list [2, 4, 6]