### PR TITLE
Document query: use correct tag for instanceof check to fix null attributes

### DIFF
--- a/src/GraphQL/DocumentElementType/RelationsType.php
+++ b/src/GraphQL/DocumentElementType/RelationsType.php
@@ -20,7 +20,6 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
-use Pimcore\Model\Document\Tag\Relation;
 use Pimcore\Model\Document\Tag\Relations;
 
 class RelationsType extends ObjectType
@@ -46,7 +45,7 @@ class RelationsType extends ObjectType
                         '_tagType' => [
                             'type' => Type::string(),
                             'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                                if ($value instanceof Relation) {
+                                if ($value instanceof Relations) {
                                     return $value->getType();
                                 }
                             }
@@ -54,7 +53,7 @@ class RelationsType extends ObjectType
                         '_tagName' => [
                             'type' => Type::string(),
                             'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                                if ($value instanceof Relation) {
+                                if ($value instanceof Relations) {
                                     return $value->getName();
                                 }
                             }


### PR DESCRIPTION
While working with the latest version (`dev-master`) of this package to query a document via GraphQL, I noticed both `_tagType` and `_tagName` would always return `null` when accessing a Relations (plural) tag whereas these attributes would have the expected values for the Relation (singular) tag. This is the query in question:

```gql
query getDocument($path: String!) {
  getDocument(path: $path) {
    ... on document_page {
      fullpath
      elements {
        ... on document_tagRelation {
          _tagName # non-null in result
          _tagType # non-null in result
        }
        ... on document_tagRelations {
          _tagName # null in result
          _tagType # null in result
          }
        }
      }
    }
  }
}
```

In the case of Relations, these attributes are set in `src/GraphQL/DocumentElementType/RelationsType.php` and it looks like this file was originally based on `src/GraphQL/DocumentElementType/RelationType.php` which explains why the two resolvers would want `$value` to be an instance of `Pimcore\Model\Document\Tag\Relation` rather than `Pimcore\Model\Document\Tag\Relations`.

This PR fixes the two `if ($value instanceof Relation)` comparisons and also removes the now unnecessary `use` statement for `Relation`. The two attributes in question now contain the expected values.

Please let me know if you have any questions or would like me to make any changes to this PR.