### PR TITLE
respect language parameter for classification store queries

### DIFF
--- a/src/GraphQL/ClassificationstoreType/Group.php
+++ b/src/GraphQL/ClassificationstoreType/Group.php
@@ -65,7 +65,7 @@ class Group extends ObjectType
                     $csValue = $value["_csValue"];
                     $groupId = $value["id"];
                     $language = $value["_language"];
-                    if ($language) {
+                    if (!$language) {
                         //TODO maybe add the "global" defaultLanguage if specified ?
                         $language = "default";
                     }


### PR DESCRIPTION
Overriding the language parameter with "default" seems like a typo to me(?)