### PR TITLE
Provide response cache

### DIFF
--- a/doc/10_GraphQL/10_Events.md
+++ b/doc/10_GraphQL/10_Events.md
@@ -8,6 +8,7 @@ All DataHub events are defined as a constant on component classes:
 - [Mutation](https://github.com/pimcore/data-hub/blob/master/src/Event/GraphQL/MutationEvents.php)
 - [Executor](https://github.com/pimcore/data-hub/blob/master/src/Event/GraphQL/ExecutorEvents.php)
 - [Listing](https://github.com/pimcore/data-hub/blob/master/src/Event/GraphQL/ListingEvents.php)
+- [Ouput cache](https://github.com/pimcore/data-hub/blob/master/src/Event/GraphQL/OutputCacheEvents.php)
 
 ## Event Listener examples
 
@@ -201,4 +202,62 @@ class GraphqlListener implements EventSubscriberInterface
     }
 }
 
+```
+
+#### Example 5: Add custom conditions to enable/disable output (responses) cache per request
+
+- `OutputCacheEvents::PRE_LOAD`: is triggered before trying to load an entry from cache, if cache is enabled. You can disable the cache  for this request by setting `$event->setUseCache(false)`. If you disable the cache, the entry won't be loaded nor saved
+- `OutputCacheEvents::PRE_SAVE`: if cache is enabled, it's triggered before saving an entry into the cache. You can use it to modify the response before it gets saved.
+
+```php
+<?php
+
+namespace AppBundle\EventListener;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\OutputCachePreLoadEvent;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\OutputCachePreSaveEvent;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\OutputCacheEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class GraphqlListener implements EventSubscriberInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            OutputCacheEvents::PRE_LOAD => 'onPreLoadCache',
+            OutputCacheEvents::PRE_SAVE => 'onPreSaveCache'
+        ];
+    }
+
+    /**
+     * @param OutputCachePreLoadEvent $event
+     */
+    public function onPreLoadCache(OutputCachePreLoadEvent $event) 
+    {
+        $uri = $event->getRequest()->getMethod();
+        
+        if(str_contains($uri, "my-special-endpoint"))
+        {
+            $event->setUseCache(false);
+        }
+    }
+
+    /**
+     * @param OutputCachePreSaveEvent $event
+     */
+    public function onPreSaveCache(OutputCachePreSaveEvent $event) 
+    {
+        $uri = $event->getRequest()->getMethod();
+        
+        if(str_contains($uri, "my-awesome-endpoint"))
+        {
+            $response = $event->getResponse();
+            // modify the response as you want it to be saved...
+
+            $event->setResponse($response);
+        }
+    }
+}
 ```

--- a/doc/10_GraphQL/README.md
+++ b/doc/10_GraphQL/README.md
@@ -50,3 +50,24 @@ for an endpoint in an iframe within Pimcore or as an additional browser tab.
 ## Events
 It is possible to customize default behavior of graphQL endpoint with event listeners. For details 
 see [Events Documentation](./10_Events.md). 
+
+
+## Output cache
+It is possible to keep a cache of the responses delivered by the endpoint, using the same default cache backend configured for Pimcore (Doctrine, Redis,...). This is specially useful to speed up the endpoint replies when it produces complex responses with many dependencies.
+
+The cache can be enabled and configured with a configuration entry like this in your `config.yml` file:
+```yml
+#### DATAHUB OUTPUT CACHE
+pimcore_data_hub:
+    graphql:
+        output_cache_enabled: true    # Enables/disables the output (responses) cache
+        output_cache_lifetime: 20     # If enabled, for how many seconds each response will be cached
+```
+By default the cache is disabled but if it is enabled and you don't specify a value for `output_cache_lifetime`, its default value is set to 30 seconds.
+
+### Disable Output Cache for a Single Request (only in DEBUG MODE)
+Just add the parameter `?pimcore_outputfilters_disabled=true` to the URL. This works in a similar way as the [Pimcore's Full Page Cache](https://pimcore.com/docs/pimcore/current/Development_Documentation/Development_Tools_and_Details/Cache/Full_Page_Cache.html).
+
+### Customize the Cache Behaviour
+It is possible to customize some behavior of output cache with event listeners. For details 
+see [Events Documentation](./10_Events.md).

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,6 +35,8 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('graphql')
                     ->children()
                         ->scalarNode('not_allowed_policy')->info('throw exception = 1, return null = 2')->defaultValue(2)->end()
+                        ->booleanNode('output_cache_enabled')->info('enables output cache for graphql responses. It is disabled by default')->defaultValue(false)->end()
+                        ->integerNode('output_cache_lifetime')->info('output cache in seconds. Default is 30 seconds')->defaultValue(30)->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Event/GraphQL/Model/OutputCachePreLoadEvent.php
+++ b/src/Event/GraphQL/Model/OutputCachePreLoadEvent.php
@@ -15,17 +15,15 @@
 namespace Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model;
 
 use Pimcore\Event\Traits\RequestAwareTrait;
-use Pimcore\Event\Traits\ResponseAwareTrait;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 
 class OutputCachePreLoadEvent extends Event
 {
     use RequestAwareTrait;
-    use ResponseAwareTrait;
 
     /**
-     * @var string
+     * @var Request
      */
     protected $request;
 
@@ -35,7 +33,7 @@ class OutputCachePreLoadEvent extends Event
     protected $useCache;
 
     /**
-     * @return string
+     * @return Request
      */
     public function getRequest()
     {
@@ -51,7 +49,7 @@ class OutputCachePreLoadEvent extends Event
     }
 
     /**
-     * @param bool $request
+     * @param bool $useCache
      */
     public function setUseCache(bool $useCache)
     {

--- a/src/Event/GraphQL/Model/OutputCachePreLoadEvent.php
+++ b/src/Event/GraphQL/Model/OutputCachePreLoadEvent.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model;
+
+use Pimcore\Event\Traits\RequestAwareTrait;
+use Pimcore\Event\Traits\ResponseAwareTrait;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+class OutputCachePreLoadEvent extends Event
+{
+    use RequestAwareTrait;
+    use ResponseAwareTrait;
+
+    /**
+     * @var string
+     */
+    protected $request;
+
+    /**
+     * @var bool
+     */
+    protected $useCache;
+
+    /**
+     * @return string
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isUseCache()
+    {
+        return $this->useCache;
+    }
+
+    /**
+     * @param bool $request
+     */
+    public function setUseCache(bool $useCache)
+    {
+        $this->useCache = $useCache;
+    }
+
+    /**
+     * @param Request $request
+     * @param bool $useCache
+     */
+    public function __construct(Request $request, bool $useCache)
+    {
+        $this->request = $request;
+        $this->useCache = $useCache;
+    }
+}

--- a/src/Event/GraphQL/Model/OutputCachePreSaveEvent.php
+++ b/src/Event/GraphQL/Model/OutputCachePreSaveEvent.php
@@ -26,9 +26,22 @@ class OutputCachePreSaveEvent extends Event
     use ResponseAwareTrait;
 
     /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
      * @var Response
      */
     protected $response;
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
 
     /**
      * @return Response

--- a/src/Event/GraphQL/Model/OutputCachePreSaveEvent.php
+++ b/src/Event/GraphQL/Model/OutputCachePreSaveEvent.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model;
+
+use Pimcore\Event\Traits\RequestAwareTrait;
+use Pimcore\Event\Traits\ResponseAwareTrait;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class OutputCachePreSaveEvent extends Event
+{
+    use RequestAwareTrait;
+    use ResponseAwareTrait;
+
+    /**
+     * @var Response
+     */
+    protected $response;
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @param Request $request
+     * @param Response $response
+     */
+    public function __construct(Request $request, Response $response)
+    {
+        $this->request = $request;
+        $this->response = $response;
+    }
+}

--- a/src/Event/GraphQL/OutputCacheEvents.php
+++ b/src/Event/GraphQL/OutputCacheEvents.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Event\GraphQL;
+
+final class OutputCacheEvents
+{
+    /**
+     * Fired to determine if a response should be cached.
+     *
+     * @Event("Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\CachePreLoadEvent")
+     *
+     * @var string
+     */
+    const PRE_LOAD = 'pimcore.datahub.graphql.cache.preLoad';
+
+    /**
+     * Fired before the response is written to cache. Can be used to set or purge
+     * data on the cached response.
+     *
+     * @Event("Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\CachePreSaveEvent")
+     *
+     * @var string
+     */
+    const PRE_SAVE = 'pimcore.datahub.graphql.cache.preSave';
+}

--- a/src/Service/OutputCacheService.php
+++ b/src/Service/OutputCacheService.php
@@ -109,7 +109,7 @@ class OutputCacheService
         $input = json_decode($request->getContent(), true);
         $input = print_r($input, true);
         
-        return md5($clientname . $input);
+        return md5("output_" . $clientname . $input);
     }
     
     private function useCache(Request $request) : bool {

--- a/src/Service/OutputCacheService.php
+++ b/src/Service/OutputCacheService.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Service;
+
+use Psr\Container\ContainerInterface;
+use Pimcore\Logger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class OutputCacheService 
+{
+    /**
+     * @var bool
+     */
+    private $cacheEnabled = false;
+    
+    /**
+     * The cached items lifetime in seconds
+     * 
+     * @var int
+     */
+    private $lifetime = 30;
+    
+    
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $config = $container->getParameter('pimcore_data_hub');
+
+        if (isset($config['graphql'])) {
+            
+            if (isset($config['graphql']['output_cache_enabled'])) {
+                $this->cacheEnabled = filter_var($config['graphql']['output_cache_enabled'], FILTER_VALIDATE_BOOLEAN);
+            }
+            
+            if (isset($config['graphql']['output_cache_lifetime'])) {
+                $this->lifetime = intval($config['graphql']['output_cache_lifetime']);
+            }
+        }
+    }
+    
+    
+    public function load(Request $request) {
+        
+        if(!$this->useCache($request)) {
+            return null;
+        }
+        
+        $cacheKey = $this->computeKey($request);
+        
+        return \Pimcore\Cache::load($cacheKey);
+    }
+    
+    
+    public function save(Request $request, JsonResponse $response, $extraTags = []) : void {
+        if ($this->useCache($request)) {
+            $cacheKey = $this->computeKey($request);
+            $clientname = $request->get('clientname');
+            
+            \Pimcore\Cache::save(
+                $response,
+                $cacheKey,
+                array_merge(["output","datahub", $clientname], $extraTags),
+                $this->lifetime);
+        }
+    }
+    
+    
+    private function computeKey(Request $request) : string {
+        $clientname = $request->get('clientname');
+        
+        $input = json_decode($request->getContent(), true);
+        $input = print_r($input, true);
+        
+        return md5($clientname . $input);
+    }
+    
+    private function useCache(Request $request) : bool {
+        if(!$this->cacheEnabled) {
+            Logger::debug("Output cache is disabled");
+            return false;
+        }
+        
+        $disableCacheForSingleRequest = false;
+        
+        if (\Pimcore::inDebugMode()){
+            $disableCacheForSingleRequest = filter_var($request->query->get('pimcore_nocache', 'false'), FILTER_VALIDATE_BOOLEAN)
+            || filter_var($request->query->get('pimcore_outputfilters_disabled', 'false'), FILTER_VALIDATE_BOOLEAN);
+        }
+        
+        if($disableCacheForSingleRequest) {
+            Logger::debug("Output cache is disabled for this request");
+            return false;
+        }
+        
+        
+        return true;
+    }
+}

--- a/tests/Service/OutputCacheServiceTest.php
+++ b/tests/Service/OutputCacheServiceTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+namespace Pimcore\Bundle\DataHubBundle\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\Bundle\DataHubBundle\Configuration;
+use Symfony\Component\HttpFoundation\Request;
+
+class OutputCacheServiceTest extends TestCase
+{    
+    const CORRECT_API_KEY = "correct_key";
+
+    public function testSecurityCheckFailsWhenNoApiKeyinRequest()
+    {   
+        // Arrange  
+        $configuration = $this->createMock(Configuration::class);  
+        $configuration->method('getSecurityConfig')
+            ->willReturn(array(
+                 "method" => Configuration::SECURITYCONFIG_AUTH_APIKEY,
+                 "apikey" => self::CORRECT_API_KEY
+            ));
+        $request = new Request();
+       
+
+        // System under Test            
+        $sut = new \Pimcore\Bundle\DataHubBundle\Service\CheckConsumerPermissionsService();
+        // Act
+        $result = $sut->performSecurityCheck($request, $configuration);
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public function testSecurityCheckFailsWhenInvalidApiKeyInRequest()
+    {
+        // Arrange  
+        $configuration = $this->createMock(Configuration::class);  
+        $configuration->method('getSecurityConfig')
+            ->willReturn(array(
+                "method" => Configuration::SECURITYCONFIG_AUTH_APIKEY,
+                "apikey" => self::CORRECT_API_KEY
+            ));
+        $request = new Request(array("apikey" => "wrong_key"));
+       
+
+        // System under Test            
+        $sut = new \Pimcore\Bundle\DataHubBundle\Service\CheckConsumerPermissionsService();
+        // Act
+        $result = $sut->performSecurityCheck($request, $configuration);
+        //Assert
+        $this->assertFalse($result);
+    }
+
+    public function testSecurityCheckPassesWhenCorrectApiKeyInQuery()
+    {
+        // Arrange  
+        $configuration = $this->createMock(Configuration::class);  
+        $configuration->method('getSecurityConfig')
+            ->willReturn(array(
+                "method" => Configuration::SECURITYCONFIG_AUTH_APIKEY,
+                "apikey" => self::CORRECT_API_KEY
+            ));
+        $request = new Request(array("apikey" => self::CORRECT_API_KEY));
+      
+
+        // System under Test            
+        $sut = new \Pimcore\Bundle\DataHubBundle\Service\CheckConsumerPermissionsService();
+        // Act
+        $result = $sut->performSecurityCheck($request, $configuration); 
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testSecurityCheckPassesWhenCorrectApiKeyInApikeyHeader()
+    {
+        // Arrange  
+        $configuration = $this->createMock(Configuration::class);  
+        $configuration->method('getSecurityConfig')
+            ->willReturn(array(
+                "method" => Configuration::SECURITYCONFIG_AUTH_APIKEY,
+                "apikey" => self::CORRECT_API_KEY
+            ));
+        $request = new Request();
+        $request->headers->set("apikey", self::CORRECT_API_KEY);
+
+        // System under Test            
+        $sut = new \Pimcore\Bundle\DataHubBundle\Service\CheckConsumerPermissionsService();
+        // Act
+        $result = $sut->performSecurityCheck($request, $configuration); 
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testSecurityCheckPassesWhenCorrectXApiKeyInApikeyHeader()
+    {
+        // Arrange  
+        $configuration = $this->createMock(Configuration::class);  
+        $configuration->method('getSecurityConfig')
+            ->willReturn(array(
+                "method" => Configuration::SECURITYCONFIG_AUTH_APIKEY,
+                "apikey" => self::CORRECT_API_KEY
+            ));
+        $request = new Request();
+        $request->headers->set("X-API-Key", self::CORRECT_API_KEY);
+        // System under Test            
+        $sut = new \Pimcore\Bundle\DataHubBundle\Service\CheckConsumerPermissionsService();
+        // Act
+        $result = $sut->performSecurityCheck($request, $configuration); 
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testSecurityCheckPrioritizesHeaderOverQueryParam()
+    {
+        // Arrange  
+        $configuration = $this->createMock(Configuration::class);  
+        $configuration->method('getSecurityConfig')
+            ->willReturn(array(
+                "method" => Configuration::SECURITYCONFIG_AUTH_APIKEY,
+                "apikey" => self::CORRECT_API_KEY
+            ));
+        $request = new Request(array("apikey", "wrong_key"));
+        $request->headers->set("apikey", self::CORRECT_API_KEY);
+        // System under Test            
+        $sut = new \Pimcore\Bundle\DataHubBundle\Service\CheckConsumerPermissionsService();
+        // Act
+        $result = $sut->performSecurityCheck($request, $configuration); 
+        // Assert
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
Draft for #273:
- config.yml file can be used to enable graphql output cache and set items lifetime. If not provided, defaults are: cache disabled, 30 seconds lifetime
- cache can be disabled for a single request (if debug mode is on) by setting query params to true (pimcore_nocache, pimcore_outputfilters_disabled)
- graphql output cache uses the default cache backend configured for pimcore (Doctrine, Redis,...)
