### PR TITLE
Add sql "in" support / use it automatically, if possible

### DIFF
--- a/src/GraphQL/Helper.php
+++ b/src/GraphQL/Helper.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Bundle\DataHubBundle\GraphQL;
 
 use Pimcore\Db;
+use Pimcore\Db\ConnectionInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Layout;
 
@@ -23,8 +24,34 @@ use Pimcore\Model\DataObject\ClassDefinition\Layout;
  */
 class Helper
 {
+    private static $mappingTable = [
+        '$gt' => '>', '$gte' => '>=',
+        '$lt' => '<', '$lte' => '<=',
+        '$like' => 'LIKE', '$notlike' => 'NOT LIKE',
+        '$notnull' => 'IS NOT NULL', '$not' => 'NOT'
+    ];
+
     public static function buildSqlCondition($defaultTable, $q, $op = null, $subject = null)
     {
+        if ($q instanceof \stdClass) {
+            return self::buildSqlConditionRecursion($defaultTable, $q);
+        }
+        // Don't return input
+    }
+
+    private static function buildSqlConditionRecursion($defaultTable, $q, $op = 'AND', $subject = null)
+    {
+        if (is_string($q)) {
+            return $q;
+        }
+
+        if (($result = self::buildInSqlCondition(Db::get(), $defaultTable, $q, $op, $subject)) !== null) {
+            return $result;
+        }
+
+        if ($q instanceof \stdClass) {
+            $q = get_object_vars($q);
+        }
 
         // Examples:
         //
@@ -47,37 +74,32 @@ class Helper
         //
         // where ( ((`o_published` = '0') )  AND  ((`o_modificationDate` > '1000') AND  ((`o_id` = '3') OR (`o_key` LIKE '%lorem-ipsum%') )  )  )
 
-        if (!$op) {
-            $op = 'AND';
-        }
-        $mappingTable = ['$gt' => '>', '$gte' => '>=', '$lt' => '<', '$lte' => '<=', '$like' => 'LIKE', '$notlike' => 'NOT LIKE', '$notnull' => 'IS NOT NULL',
-                '$not' => 'NOT'];
+        $db = Db::get();
+        $mappingTable = self::$mappingTable;
         $ops = array_keys($mappingTable);
 
-        $db = Db::get();
-
         $parts = [];
-        if (is_string($q)) {
-            return $q;
-        }
-
         foreach ($q as $key => $value) {
-            if (array_search(strtolower($key), ['$and', '$or']) !== false) {
+            if (strtolower($key) === '$in') {
+                $parts[] = self::buildInSqlCondition($db, $defaultTable, $value);
+            } elseif (strtolower($key) === strtolower('$notIn')) {
+                $parts[] = self::buildInSqlCondition($db, $defaultTable, $value, 'NOT');
+            } elseif (array_search(strtolower($key), ['$and', '$or']) !== false) {
                 $childOp = strtolower($key) == '$and' ? 'AND' : 'OR';
 
                 if (is_array($value)) {
                     $childParts = [];
                     foreach ($value as $arrItem) {
-                        $childParts[] = self::buildSqlCondition($defaultTable, $arrItem, $childOp);
+                        $childParts[] = self::buildSqlConditionRecursion($defaultTable, $arrItem, $childOp);
                     }
                     $parts[] = implode(' ' . $childOp . ' ', $childParts);
                 } else {
-                    $parts[] = self::buildSqlCondition($defaultTable, $value, $childOp);
+                    $parts[] = self::buildSqlConditionRecursion($defaultTable, $value, $childOp);
                 }
             } else {
                 if (is_array($value)) {
                     foreach ($value as $subValue) {
-                        $parts[] = self::buildSqlCondition($defaultTable, $subValue);
+                        $parts[] = self::buildSqlConditionRecursion($defaultTable, $subValue);
                     }
                 } elseif ($value instanceof \stdClass) {
                     $objectVars = get_object_vars($value);
@@ -91,7 +113,7 @@ class Helper
                             }
                         } else {
                             if ($objectValue instanceof \stdClass) {
-                                $parts[] = self::buildSqlCondition($defaultTable, $objectValue, null, $objectVar);
+                                $parts[] = self::buildSqlConditionRecursion($defaultTable, $objectValue, null, $objectVar);
                             } else {
                                 $parts[] = '(' . self::quoteAbsoluteColumnName($defaultTable, $objectVar) . ' = ' . $db->quote($objectValue) . ')';
                             }
@@ -114,9 +136,7 @@ class Helper
             }
         }
 
-        $subCondition = ' (' . implode(' ' . $op . ' ', $parts) . ' ) ';
-
-        return $subCondition;
+        return ' (' . implode(' ' . $op . ' ', $parts) . ' ) ';
     }
 
     protected static function quoteAbsoluteColumnName($defaultTable, $columnName)
@@ -140,5 +160,99 @@ class Helper
         } else if ($def instanceof Data) {
             $fieldDefinitions[$def->getName()] = $def;
         }
+    }
+
+    public static function buildInSqlCondition(
+        ConnectionInterface $db,
+        string $table,
+        $queries,
+        $objectOperator = null,
+        $objectField = null
+
+    ): ?string
+    {
+        if ($queries instanceof \stdClass) {
+            $queries = get_object_vars($queries);
+            if (count($queries) === 1 && isset($queries['$or'])) {
+                $objectOperator = null;
+                $queries = $queries['$or'];
+            }
+        } elseif (!is_array($queries)) {
+            $queries = [$queries]; // Only one query
+        }
+
+        $objectValues = [];
+        foreach ($queries as $queryIndex => $queryData) {
+            if (is_int($queryIndex) && $queryData instanceof \stdClass) {
+                foreach (get_object_vars($queryData) as $newObjectField => $objectValue) {
+                    if (isset($objectField) && $newObjectField !== $objectField) {
+                        return null; // More then one field
+                    }
+                    $objectField = $newObjectField;
+                    if ($objectValue instanceof \stdClass) {
+                        foreach (get_object_vars($objectValue) as $newObjectOperator => $innerObjectValue) {
+                            if (isset($objectOperator) && $newObjectOperator !== $objectOperator) {
+                                return null; // More then one operator
+                            }
+                            $objectOperator = $newObjectOperator;
+                            $objectValues[] = $innerObjectValue;
+                        }
+                    } else {
+                        $objectValues = array_merge($objectValues, (array)$objectValue);
+                    }
+                }
+            } elseif (!isset($objectField)) {
+                if (strpos($queryIndex, '$') === 0) {
+                    $objectField = $queryIndex;
+                    $objectValues = (array)$queryData;
+                } else {
+                    return null; // No field found
+                }
+            } else {
+                return null; // No in query
+            }
+        }
+
+        if (empty($objectValues)) {
+            return null;
+        }
+
+        $notOperator = '';
+        if (isset($objectOperator)) {
+            if ($objectOperator === 'OR') {
+                $objectOperator = 'IN';
+            } elseif ($objectOperator === 'NOT') {
+                $notOperator = 'NOT ';
+                $objectOperator = 'IN';
+            } elseif (isset(self::$mappingTable[strtolower($objectOperator)])) {
+                $objectOperator = self::$mappingTable[strtolower($objectOperator)];
+            } else {
+                return null; // Operator not found
+            }
+        } else {
+            $objectOperator = 'IN';
+        }
+
+        if ($objectOperator === 'IN') {
+            $objectValues = implode(', ', array_map([$db, 'quote'], $objectValues));
+            return self::quoteAbsoluteColumnName($table, $objectField)
+                . ' ' . $notOperator . $objectOperator . ' (' . $objectValues . ')';
+        }
+        if (count($objectValues) === 1) {
+            return $notOperator . '( ' . self::quoteAbsoluteColumnName($table, $objectField)
+                . ' ' . $objectOperator . ' ' . $db->quote($objectValues[0]) . ')';
+        }
+
+        $identifier = $db->quoteIdentifier($table === 'assets' ? 'id' : 'o_id');
+        $objectSelects = [];
+        foreach ($objectValues as $objectValue) {
+            $objectSelects[] = 'SELECT ' . $identifier
+                . ' FROM ' . $db->quoteIdentifier($table)
+                . ' WHERE ' . self::quoteAbsoluteColumnName($table, $objectField)
+                . ' ' . $objectOperator . ' ' . $db->quote($objectValue);
+        }
+        return $identifier . ' ' . $notOperator . 'IN ('
+            . implode(' UNION ALL ', $objectSelects)
+            . ')';
     }
 }


### PR DESCRIPTION
So far i have made such queries:

`{"$or":[{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/240-06 A5-C 144/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZG 703/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZG 704/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZG 901/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZG 902/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZG 903 N/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZG 903/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZG 905/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZZ 702/%/%"}},{"o_path":{"$like":"/Rollen und Watte/BONDING ADHESIVE/ZZ 902/%/%"}}]}`

Of course, this always resulted in sql queries with much OR operators.

Now you can use "$in" or "$notIn" too.
But also "$or" queries should now be optimized.

Important:
Since they only make sense, if they are not nested arbitrarily, you can only specify one additional operator and one field.

