### PR TITLE
read query variables after preExecute event

### DIFF
--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -145,6 +145,10 @@ class WebserviceController extends FrontendController
 
             $this->eventDispatcher->dispatch($event, ExecutorEvents::PRE_EXECUTE);
 
+            if ($event->getRequest() instanceof Request) {
+                $variableValues =  $event->getRequest()->get('variables');
+            }
+
             $result = GraphQL::executeQuery(
                 $event->getSchema(),
                 $event->getQuery(),

--- a/src/Event/GraphQL/Model/ExecutorEvent.php
+++ b/src/Event/GraphQL/Model/ExecutorEvent.php
@@ -26,7 +26,7 @@ class ExecutorEvent extends Event
     use ResponseAwareTrait;
 
     /**
-     * @var string
+     * @var mixed
      */
     protected $request;
 
@@ -46,7 +46,7 @@ class ExecutorEvent extends Event
     protected $context;
 
     /**
-     * @return string
+     * @return mixed
      */
     public function getRequest()
     {
@@ -54,11 +54,12 @@ class ExecutorEvent extends Event
     }
 
     /**
-     * @param string $request
+     * @param mixed $request
+     * @param bool $asString
      */
-    public function setRequest(string $request)
+    public function setRequest($request, $asString = true)
     {
-        $this->request = $request;
+        $this->request = $asString ? (string)$request : $request;
     }
 
     /**


### PR DESCRIPTION
this allows modification of the variable values (and therefore the whole query - if needed) in the preExecute event.
the change also introduces a backward compatible way to set the request property of the ExecutorEvent to an actual request object (like the event is created by it's constructor) and not only to a string