### PR TITLE
Default language parameter in classification store queries

### DIFF
--- a/src/GraphQL/ClassificationstoreType/Group.php
+++ b/src/GraphQL/ClassificationstoreType/Group.php
@@ -66,8 +66,11 @@ class Group extends ObjectType
                     $groupId = $value["id"];
                     $language = $value["_language"];
                     if (!$language) {
-                        //TODO maybe add the "global" defaultLanguage if specified ?
-                        $language = "default";
+                        // Let's try to "inherit" the language from what's already been parsed from this query
+                        $language = $this->getGraphQlService()->getLocaleService()->getLocale();
+                        if (!$language) {
+                            $language = "default";
+                        }
                     }
 
                     $keyRelations = new Classificationstore\KeyGroupRelation\Listing();


### PR DESCRIPTION
When the language is not indicated in a Classification Store query, the `defaultLanguage` (if present) should be taken into account before stating that the language should be set to `default`.

This modification will take into account the Locale of the GraphQL service. The Locale property contains the value of the `defaultLanguage` when this parameter is specified in the query.