### PR TITLE
use already parsed variables as fallback

### DIFF
--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -146,7 +146,7 @@ class WebserviceController extends FrontendController
             $this->eventDispatcher->dispatch($event, ExecutorEvents::PRE_EXECUTE);
 
             if ($event->getRequest() instanceof Request) {
-                // $variableValues =  $event->getRequest()->get('variables');
+                $variableValues =  $event->getRequest()->get('variables', $variableValues);
             }
 
             $result = GraphQL::executeQuery(


### PR DESCRIPTION
fixes #304

The original request object's parameter bags somehow aren't populated (I guess that's why originally the variable values are parsed from the request body).
One may ask why after the event the variable values are read from the parameter bags (and not via request body parsing like before). The reason is that inside the event setting a single parameter (like variables) via request body would be cumbersome.
The solution for now is to provide the variable values from the original request body are provided as default/fallback while reading the variables from the parameter bags (so if the parameter bags are empty the originally parsed variable values are returned).