### PR TITLE
Fix 'Call to a member function resolveObjectGetter() on array' when creating and image via GraphQL

### DIFF
--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -831,7 +831,7 @@ class MutationType extends ObjectType
                         'type' => $assetType,
                         'resolve' => static function ($value, $args, $context, ResolveInfo $info) use ($queryResolver) {
                             $args["id"] = $value["id"];
-                            $value = $queryResolver->resolveObjectGetter($value, $args, $context, $info);
+                            $value = $queryResolver($value, $args, $context, $info);
 
                             return $value;
                         }


### PR DESCRIPTION
When using GraphQL API to create an image asset, the server replies with an HTTP 500 error and the following stacktrace:

**Request**
``` graphql
mutation createMyImage($path: String!, $filename: String!, $imageData: String!) {
  createAsset(path: $path, filename: $filename, type: "image", input: {data: $imageData, filename: $filename}) {
    success
    message
    assetData {
         modificationDate
    }   
  }
}
```
**Variables**
``` json
{
  "filename": "my-image.png",
  "path": "/my-images",
  "imageData": "/9j/4AAQSkZJRg..."
}
```
**Error**
``` php
Call to a member function resolveObjectGetter() on array 
in vendor/pimcore/data-hub/src/GraphQL/Mutation/MutationType.php (line 834)

                        "assetData" => [
                            'args' => ['defaultLanguage' => ['type' => Type::string()]],
                            'type' => $assetType,
                            'resolve' => static function ($value, $args, $context, ResolveInfo $info) use ($queryResolver) {
                                $args["id"] = $value["id"];
                                $value = $queryResolver->resolveObjectGetter($value, $args, $context, $info);
                                return $value;
                            }
                        ]
                    ],
```

After changing the line in the same way as line 937 already is, the asset creation works as expected.