### PR TITLE
Added support to set metadata on assets

### DIFF
--- a/src/GraphQL/AssetType/AssetInputType.php
+++ b/src/GraphQL/AssetType/AssetInputType.php
@@ -49,6 +49,17 @@ class AssetInputType extends InputObjectType
             'parentId' => Type::int(),
             'data' => [
                 'type' => Type::string(),
+            ],
+            'metadata' => [
+                'type' => Type::listOf(new InputObjectType([
+                    'name' => 'MetadataItem',
+                    'fields' => [
+                        'name'  => Type::nonNull(Type::string()),
+                        'type' => Type::nonNull(Type::string()),
+                        'data' => Type::string(),
+                        'language' => Type::string()
+                    ]
+                ]))
             ]
         ];
     }


### PR DESCRIPTION
Currently Datahub doesn't support adding/updating metadata in assets mutations, even though I can get the metadata in queries. By adding the 'Metadata' input parameter, the existing code is able to save/replace the metadata. To test it you can use the createAsset or the updateAsset mutations, for instance:

```graphql
mutation ($filename: String!, $path: String, $input: AssetInput) {
  createAsset(filename: $filename, path: $path, type: "document", input: $input) {
    success
    message
    assetData {
      metadata {
        name
        type
        data
      }
    }
  }
}

{
  "filename": "my-doc.pdf",
  "path": "/telco",  
  "input": {
    "filename": "my-doc.pdf",
    "metadata": [
      {
        "name": "my-metadata",
        "type": "input",
        "data": "my-value"
      },
      {
        "name": "another-metadata",
        "type": "input",
        "data": "another-value"
      }
    ],
    data: "base 64 encoded data"
  }
}
```