### PR TITLE
[Workspaces] Use add instead of insert to add new store record

### DIFF
--- a/src/Resources/public/js/workspace/abstract.js
+++ b/src/Resources/public/js/workspace/abstract.js
@@ -178,7 +178,7 @@ pimcore.plugin.datahub.workspace.abstract = Class.create({
     },
 
     onAdd: function (btn, ev) {
-        this.grid.store.insert(0, {
+        this.grid.store.add({
             read: true,
             cpath: ""
         });


### PR DESCRIPTION
This PR changes the UI behavior of adding new records to the workspace store. Instead of prepending new records this appends the newly created record. This makes it more intuitive for the user, which expects the record to be added at the bottom.