### PR TITLE
Element tags mutation

### DIFF
--- a/src/GraphQL/AssetType/AssetInputType.php
+++ b/src/GraphQL/AssetType/AssetInputType.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\AssetType;
 
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type;
+use Pimcore\Bundle\DataHubBundle\GraphQL\ElementTag;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 
@@ -49,15 +50,7 @@ class AssetInputType extends InputObjectType
             'data' => [
                 'type' => Type::string(),
             ],
-            'tags' => [
-                'type' => Type::listOf(new InputObjectType([
-                    'name' => 'ElementTag',
-                    'fields' => [
-                        'id' => Type::id(),
-                        'path' => Type::string(),
-                    ]
-                ]))
-            ],
+            'tags' => ElementTag::getElementTagInputTypeDefinition(),
             'metadata' => [
                 'type' => Type::listOf(new InputObjectType([
                     'name' => 'MetadataItem',

--- a/src/GraphQL/AssetType/AssetInputType.php
+++ b/src/GraphQL/AssetType/AssetInputType.php
@@ -49,6 +49,15 @@ class AssetInputType extends InputObjectType
             'data' => [
                 'type' => Type::string(),
             ],
+            'tags' => [
+                'type' => Type::listOf(new InputObjectType([
+                    'name' => 'ElementTag',
+                    'fields' => [
+                        'id' => Type::id(),
+                        'path' => Type::string(),
+                    ]
+                ]))
+            ],
             'metadata' => [
                 'type' => Type::listOf(new InputObjectType([
                     'name' => 'MetadataItem',

--- a/src/GraphQL/DocumentType/DocumentLinkInputType.php
+++ b/src/GraphQL/DocumentType/DocumentLinkInputType.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DocumentType;
 
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type;
+use Pimcore\Bundle\DataHubBundle\GraphQL\ElementTag;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 
@@ -55,7 +56,8 @@ class DocumentLinkInputType extends InputObjectType
 //                    ]]),
             'direct' => Type::string(),
             'linktype' => Type::string(),
-            'href' => Type::string()
+            'href' => Type::string(),
+            'tags' => ElementTag::getElementTagInputTypeDefinition(),
         ];
     }
 }

--- a/src/GraphQL/ElementTag.php
+++ b/src/GraphQL/ElementTag.php
@@ -33,7 +33,7 @@ class ElementTag extends ObjectType
      */
     public static function getElementTagInputTypeDefinition()
     {
-        if(!isset(self::$tagTypeCache['ElementTag'])) {
+        if (!isset(self::$tagTypeCache['ElementTag'])) {
             self::$tagTypeCache['ElementTag'] = [
                 'type' => Type::listOf(new InputObjectType([
                     'name' => 'ElementTag',
@@ -44,6 +44,7 @@ class ElementTag extends ObjectType
                 ]))
             ];
         }
+
         return self::$tagTypeCache['ElementTag'];
     }
 

--- a/src/GraphQL/ElementTag.php
+++ b/src/GraphQL/ElementTag.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\DataHubBundle\GraphQL;
 
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
@@ -22,6 +23,29 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 class ElementTag extends ObjectType
 {
     use ServiceTrait;
+
+    protected static $tagTypeCache = [];
+
+    /**
+     * Type definition for ElementTag
+     *
+     * @return array
+     */
+    public static function getElementTagInputTypeDefinition()
+    {
+        if(!isset(self::$tagTypeCache['ElementTag'])) {
+            self::$tagTypeCache['ElementTag'] = [
+                'type' => Type::listOf(new InputObjectType([
+                    'name' => 'ElementTag',
+                    'fields' => [
+                        'id' => Type::id(),
+                        'path' => Type::string(),
+                    ]
+                ]))
+            ];
+        }
+        return self::$tagTypeCache['ElementTag'];
+    }
 
     /**
      * AssetTag constructor.

--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -23,8 +23,8 @@ use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\MutationTypeEvent;
 use Pimcore\Bundle\DataHubBundle\Event\GraphQL\MutationEvents;
-use Pimcore\Bundle\DataHubBundle\GraphQL\FieldHelper\DataObjectFieldHelper;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ElementTag;
+use Pimcore\Bundle\DataHubBundle\GraphQL\FieldHelper\DataObjectFieldHelper;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ElementIdentificationTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ElementTagTrait;
@@ -268,7 +268,7 @@ class MutationType extends ObjectType
                         self::{$inputProcessorFn}($value, $args, $context, $info, $element, $processors);
                         if (isset($args['input']['tags']) && ($tag_input = $args['input']['tags'])) {
                             $tags = $me->getTagsFromInput($tag_input);
-                            if(false === $tags) {
+                            if (false === $tags) {
                                 return [
                                     'success' => false,
                                     'message' => 'no "id" nor "path" tag data defined for tag, or tag not found',
@@ -622,7 +622,7 @@ class MutationType extends ObjectType
                                 //TODO: ask pimcore/pimcore to implement something like Asset::setTags
                                 if ($key == 'tags') {
                                     $tags = $me->getTagsFromInput($value);
-                                    if(false === $tags) {
+                                    if (false === $tags) {
                                         return [
                                             'success' => false,
                                             'message' => 'no "id" nor "path" tag data defined for tag, or tag not found',
@@ -830,7 +830,7 @@ class MutationType extends ObjectType
                             call_user_func_array($processor, [$object, $value, $args, $context, $info]);
                         } elseif ($key == 'tags') {
                             $tags = $me->getTagsFromInput($value);
-                            if(false === $tags) {
+                            if (false === $tags) {
                                 return [
                                     'success' => false,
                                     'message' => 'no "id" nor "path" tag data defined for tag, or tag not found',

--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -850,7 +850,7 @@ class MutationType extends ObjectType
                     'parentId' => ['type' => Type::int()],
                     'type' => ['type' => Type::nonNull(Type::string()), 'description' => 'image or whatever'],
                     'input' => $this->getGraphQlService()->getAssetTypeDefinition('asset_input'),
-                ], 'resolve' => static function ($value, $args, $context, ResolveInfo $info) use ($omitPermissionCheck,$me) {
+                ], 'resolve' => static function ($value, $args, $context, ResolveInfo $info) use ($omitPermissionCheck, $me) {
                     $parent = null;
 
                     if (isset($args['parentId'])) {
@@ -888,7 +888,7 @@ class MutationType extends ObjectType
                             //TODO: ask pimcore/pimcore to implement something like Asset::setTags
                             if ($key == 'tags') {
                                 $tags = $me->getTagsFromInput($value);
-                                if(false === $tags) {
+                                if (false === $tags) {
                                     return [
                                         'success' => false,
                                         'message' => 'no "id" nor "path" tag data defined for tag, or tag not found',
@@ -977,7 +977,7 @@ class MutationType extends ObjectType
                             //TODO: ask pimcore/pimcore to implement something like Asset::setTags
                             if ($key == 'tags') {
                                 $tags = $me->getTagsFromInput($value);
-                                if(false === $tags) {
+                                if (false === $tags) {
                                     return [
                                         'success' => false,
                                         'message' => 'no "id" nor "path" tag data defined for tag, or tag not found',

--- a/src/GraphQL/Traits/ElementTagTrait.php
+++ b/src/GraphQL/Traits/ElementTagTrait.php
@@ -44,4 +44,45 @@ trait ElementTagTrait
 
         return $result;
     }
+
+    /**
+     * @param string $element_type
+     * @param int $id
+     * @param array $tags
+     *
+     * @return boolean
+     */
+    protected function setTags(string $element_type, int $id, $tags)
+    {
+        $tag = new Tag;
+        $tag->getDao()->setTagsForElement($element_type, $id, $tags);
+        return true;
+    }
+
+    /**
+     * @param array $input
+     *
+     * @return array|boolean
+     */
+    protected function getTagsFromInput(array $input)
+    {
+        $tags = [];
+        foreach ($input as $idx => $tag_input) {
+            if (isset($tag_input['id']) && $tag_input['id']) {
+                $tag_id = $tag_input['id'];
+                $tag = Tag::getById($tag_input['id']);
+            } elseif (isset($tag_input['path']) && $tag_input['path']) {
+                $tag_id = $tag_input['path'];
+                $tag = Tag::getByPath($tag_input['path']);
+            } else {
+                return false;
+            }
+            if (!$tag) {
+                return false;
+            }
+            $tags[] = $tag;
+        }
+        return $tags;
+    }
+
 }

--- a/src/GraphQL/Traits/ElementTagTrait.php
+++ b/src/GraphQL/Traits/ElementTagTrait.php
@@ -50,19 +50,20 @@ trait ElementTagTrait
      * @param int $id
      * @param array $tags
      *
-     * @return boolean
+     * @return bool
      */
     protected function setTags(string $element_type, int $id, $tags)
     {
         $tag = new Tag;
         $tag->getDao()->setTagsForElement($element_type, $id, $tags);
+
         return true;
     }
 
     /**
      * @param array $input
      *
-     * @return array|boolean
+     * @return array|bool
      */
     protected function getTagsFromInput(array $input)
     {
@@ -82,7 +83,7 @@ trait ElementTagTrait
             }
             $tags[] = $tag;
         }
+
         return $tags;
     }
-
 }


### PR DESCRIPTION
This pull request fixes #361 

Now it's possible to make the following mutation requests: 

```graphql
mutation test ($id:Int, $input: AssetInput) {
  
  updateAsset(id:$id, input: $input) {
    success
    message
    assetData {
      tags {
        id
        name
        path
      }
    }
  }
  
}
```

Variables:

```json
{
  "id": 7173,
  "input": {
    "tags": [
      {
        "id": "1"
      },
      {
        "path": "/Brand/BASK kids"
      }
    ]
  }
}
```

Response:

```json
{
  "data": {
    "updateAsset": {
      "success": true,
      "message": "asset updated: 7173",
      "assetData": {
        "tags": [
          {
            "id": "1",
            "name": "Brand",
            "path": "/Brand"
          },
          {
            "id": "2",
            "name": "BASK kids",
            "path": "/Brand/BASK kids"
          }
        ]
      }
    }
  }
}
```

And almost the same for `createAsset`. 