### PR TITLE
$value is not a instance of checkbox

### DIFF
--- a/src/GraphQL/DocumentElementType/BlockType.php
+++ b/src/GraphQL/DocumentElementType/BlockType.php
@@ -35,7 +35,7 @@ class BlockType extends ObjectType
                         '_editableName' => [
                             'type' => Type::string(),
                             'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                                if ($value instanceof Checkbox) {
+                                if ($value) {
                                     return $value->getName();
                                 }
                             }
@@ -43,7 +43,7 @@ class BlockType extends ObjectType
                         '_editableType' => [
                             'type' => Type::string(),
                             'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                                if ($value instanceof Checkbox) {
+                                if ($value) {
                                     return $value->getType();
                                 }
                             }

--- a/src/GraphQL/DocumentElementType/BlockType.php
+++ b/src/GraphQL/DocumentElementType/BlockType.php
@@ -35,7 +35,7 @@ class BlockType extends ObjectType
                         '_editableName' => [
                             'type' => Type::string(),
                             'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                                if ($value) {
+                                if ($value instanceof Block) {
                                     return $value->getName();
                                 }
                             }
@@ -43,7 +43,7 @@ class BlockType extends ObjectType
                         '_editableType' => [
                             'type' => Type::string(),
                             'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
-                                if ($value) {
+                                if ($value instanceof Block) {
                                     return $value->getType();
                                 }
                             }


### PR DESCRIPTION
I were having issue with BlockType.
when I request for query 
 ...on document_editableBlock{
          _editableName
          _editableType
          indices
        }
it return null value of editable name and type. but when removed condition of instance of checkbox. it started working. So I am proposing this change to plugin.
Because I don't want to change in my vendor folder. it will create problem while up-gradation. So If this change find correct then please merge.