### PR TITLE
fix rebuild definitions command

### DIFF
--- a/src/Command/GraphQL/RebuildDefinitionsCommand.php
+++ b/src/Command/GraphQL/RebuildDefinitionsCommand.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataHubBundle\Command\GraphQL;
 
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Console\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -74,5 +75,7 @@ class RebuildDefinitionsCommand extends AbstractCommand
         }
 
         $this->output->writeln('done');
+
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
When running this command with a new version of PimcoreX (Symfony) we got the following error:
```
Return value of "Pimcore\Bundle\DataHubBundle\Command\GraphQL\RebuildDefinitionsCommand::execute()" must be of the type int, "null" returned.
```

This PR simply return `Symfony\Component\Console\Command\Command::SUCCESS` (`SUCCESS = 0`)