### PR TITLE
Fix undefined array key "url" in AssetType resolver

### DIFF
--- a/src/GraphQL/Resolver/AssetType.php
+++ b/src/GraphQL/Resolver/AssetType.php
@@ -202,7 +202,7 @@ class AssetType
     public function resolveResolutions($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null)
     {
         $types = $args['types'];
-        $thumbnail = $value['url'];
+        $thumbnail = $value['url'] ?? null;
 
         $asset = null;
         if ($thumbnail instanceof Asset\Image\Thumbnail) {


### PR DESCRIPTION
Fix undefined array key "url" in AssetType resolver.