### PR TITLE
fix video data resolver

### DIFF
--- a/src/GraphQL/Resolver/Video.php
+++ b/src/GraphQL/Resolver/Video.php
@@ -129,7 +129,7 @@ class Video
                 $asset = $value->getData();
                 $fieldHelper = $this->getGraphQlService()->getAssetFieldHelper();
                 $fieldHelper->extractData($data, $asset, $args, $context, $resolveInfo);
-                $data['data'] = $data['data'] ? base64_encode($data['data']) : null;
+                $data['data'] = isset($data['data']) && !empty($data['data']) ? base64_encode($data['data']) : null;
                 $data['__elementSubtype'] = $asset->getType();
 
                 return $data;


### PR DESCRIPTION
This PR fixes the issue to get the video data on `Video` types:

When run the query:
```
videoTest {
          type
          __typename
          data {
            __typename
            ... on asset {
              fullpath
            }
          }
        }
```

There was the error:
```
"message": "Warning: Undefined array key \"data\""
```