### PR TITLE
Fix warnings when adding operators to configuration

### DIFF
--- a/src/GraphQL/Helper.php
+++ b/src/GraphQL/Helper.php
@@ -37,15 +37,18 @@ class Helper
         foreach ($parts as $key => $value) {
             foreach ($columns as $column) {
                 $attributes = $column['attributes'];
-                $name = $attributes['attribute'];
+                
+                if (isset($attributes['attribute'])) {
+                    $name = $attributes['attribute'];
 
-                if (strpos($name, '~') !== false) {
-                    $nameParts = explode('~', $name);
-                    $brickName = $nameParts[0];
-                    $brickKey = $nameParts[1];
-                    if ($brickKey === $key) {
-                        $list->addObjectbrick($brickName);
-                        $mappingTable[$brickKey] = 1;
+                    if (strpos($name, '~') !== false) {
+                        $nameParts = explode('~', $name);
+                        $brickName = $nameParts[0];
+                        $brickKey = $nameParts[1];
+                        if ($brickKey === $key) {
+                            $list->addObjectbrick($brickName);
+                            $mappingTable[$brickKey] = 1;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When developing and adding operators to the config, the add join function fails because an operator does not have a attribute field defined. I do not know if this is the best solution to the problem, but it fixes the warnings and the query still runs just fine.