### PR TITLE
Fix Video fullpath and imageThumbnail

### DIFF
--- a/src/GraphQL/AssetType/AssetType.php
+++ b/src/GraphQL/AssetType/AssetType.php
@@ -86,7 +86,8 @@ class AssetType extends ObjectType
             'fullpath' => [
                 'type' => Type::string(),
                 'args' => [
-                    'thumbnail' => ['type' => Type::string()]
+                    'thumbnail' => ['type' => Type::string()],
+                    'format' => ['type' => Type::string()]
                 ],
                 'resolve' => [$resolver, 'resolvePath'],
             ],

--- a/src/GraphQL/Resolver/AssetType.php
+++ b/src/GraphQL/Resolver/AssetType.php
@@ -113,21 +113,26 @@ class AssetType
     {
         $asset = $this->getAssetFromValue($value, $context);
 
-        if ($asset instanceof Asset\Image || $asset instanceof Asset\Video) {
-            $value = isset($args['thumbnail']) ? $asset->getThumbnail($args['thumbnail'], false) : $asset->getFullPath();
+        if ($asset instanceof Asset\Image) {
+            return isset($args['thumbnail']) ? $asset->getThumbnail($args['thumbnail'], false) : $asset->getFullPath();
+        } elseif ($asset instanceof Asset\Video) {
 
-            if ($asset instanceof Asset\Video) {
-                //TODO temporary workaround for https://github.com/pimcore/data-hub/issues/392
-                // we should add format parameter to the schema
-                if ($value) {
-                    $formats = $value['formats'] ?? [];
-                    $firstFormat = array_values($formats)[0] ?? null;
-                    if ($firstFormat) {
-                        return $firstFormat;
+            if(isset($args['format'])) {
+
+                if($args['format'] == 'image') {
+                    return isset($args['thumbnail']) ? $asset->getImageThumbnail($args['thumbnail']) : $asset->getFullPath();
+                } else {
+                    $value = $asset->getThumbnail($args['thumbnail']);
+                    if ($value) {
+                        $formats = $value['formats'] ?? [];
+                        $format = $formats[$args['format']] ?? null;
+                        if ($format) {
+                            return $format;
+                        }
                     }
                 }
             } else {
-                return $value;
+                return isset($args['thumbnail']) ? $asset->getImageThumbnail($args['thumbnail']) : $asset->getFullPath();
             }
         } elseif ($asset instanceof Asset\Document) {
             return isset($args['thumbnail']) ? $asset->getImageThumbnail($args['thumbnail']) : $asset->getFullPath();


### PR DESCRIPTION
This fixes the broken fullpath param on video assets and adds correct imageThumbnail support for video assets

... on asset {
id
image: fullpath(thumbnail: "thumb")
fullpath
}

Bug produced in #392

**New Format Feature:**
For preview thumbnail image or the video thumbnail:
... on asset {
id
image: fullpath(thumbnail: "imageThumb", format: "image")
mimetype
fullpath: fullpath(thumbnail: "videoThumb", format: "mp4")
}

Previous PR #415 can be deleted