### PR TITLE
Fix Installer.php so that bundle properly reports as installed

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -81,4 +81,15 @@ class Installer extends AbstractInstaller
 
         return true;
     }
+
+    public function isInstalled()
+    {
+        try {
+            Db::get()->fetchOne('SELECT `cid` FROM `plugin_datahub_workspaces_document` LIMIT 1;');
+
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
`isInstalled()` would otherwise always return `false` since updating to 1.1.0