### PR TITLE
fix: block create configuration if there is "-" in the name

### DIFF
--- a/src/Resources/public/js/adapter/graphql.js
+++ b/src/Resources/public/js/adapter/graphql.js
@@ -23,7 +23,7 @@ pimcore.plugin.datahub.adapter.graphql = Class.create({
     },
 
     addConfigurationComplete: function (type, button, value, object) {
-        var regresult = value.match(/[a-zA-Z0-9_\-]+/);
+        var regresult = value.match(/[a-zA-Z0-9_]+/);
         if (button == "ok" && value.length > 2 && regresult == value) {
             Ext.Ajax.request({
                 url: "/admin/pimcoredatahub/config/add",


### PR DESCRIPTION
 if there is a '-' in the configuration name, it's crash while loading, so do the check in creation.