### PR TITLE
[Config Improvement] Do not normalize key when using symfony-config storage

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -55,6 +55,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('configurations')
+                    ->normalizeKeys(false)
                     ->variablePrototype()->end()
                 ->end()
             ->end();


### PR DESCRIPTION
Resolves #441