### PR TITLE
Fix usage of FieldcollectionDefinition and ObjectbrickDefinition

### DIFF
--- a/src/GraphQL/DataObjectMutationFieldConfigGenerator/Fieldcollections.php
+++ b/src/GraphQL/DataObjectMutationFieldConfigGenerator/Fieldcollections.php
@@ -42,7 +42,7 @@ class Fieldcollections extends Base
 
             $allowedFcTypes = [];
             foreach ($list as $fcDef) {
-                $allowedFcTypes[] = $fcDef->getName();
+                $allowedFcTypes[] = $fcDef->getKey();
             }
         }
 

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/AbstractTable.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/AbstractTable.php
@@ -22,7 +22,8 @@ use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
-use Pimcore\Model\DataObject\Fieldcollection\Definition;
+use Pimcore\Model\DataObject\Fieldcollection\Definition as FieldcollectionDefinition;
+use Pimcore\Model\DataObject\Objectbrick\Definition as ObjectbrickDefinition;
 
 abstract class AbstractTable extends Base
 {
@@ -81,10 +82,10 @@ abstract class AbstractTable extends Base
      */
     public function getFieldType(Data $fieldDefinition, $class = null, $container = null)
     {
-        if ($class instanceof Definition) {
-            $name = 'fieldcollection_' . $class->getKey() . '_' . $fieldDefinition->getName();
-        } elseif ($class instanceof \Pimcore\Model\DataObject\Objectbrick\Definition) {
+        if ($class instanceof ObjectbrickDefinition) {
             $name = 'objectbrick_' . $class->getKey() . '_' . $fieldDefinition->getName();
+        } elseif ($class instanceof FieldcollectionDefinition) {
+            $name = 'fieldcollection_' . $class->getKey() . '_' . $fieldDefinition->getName();
         } else {
             $name = 'object_' . $class->getName() . '_' . $fieldDefinition->getName();
         }

--- a/src/GraphQL/DataObjectType/BlockEntryType.php
+++ b/src/GraphQL/DataObjectType/BlockEntryType.php
@@ -81,8 +81,6 @@ class BlockEntryType extends ObjectType implements ContainerAwareInterface
     {
         if ($this->class instanceof Definition) {
             $name = $this->class->getKey();
-        } elseif ($this->class instanceof \Pimcore\Model\DataObject\Objectbrick\Definition) {
-            $name = $this->class->getKey();
         } else {
             $name = $this->class->getName();
         }

--- a/src/GraphQL/DataObjectType/MultihrefMetadataType.php
+++ b/src/GraphQL/DataObjectType/MultihrefMetadataType.php
@@ -48,7 +48,7 @@ class MultihrefMetadataType extends ObjectType
         $this->class = $class;
         $this->setGraphQlService($graphQlService);
         $this->fieldDefinition = $fieldDefinition;
-        $name = ($class instanceof Definition || $class instanceof \Pimcore\Model\DataObject\Objectbrick\Definition) ? $class->getKey() : $class->getName();
+        $name = ($class instanceof Definition) ? $class->getKey() : $class->getName();
 
         $config['name'] = 'object_'.$name.'_'.$fieldDefinition->getName();
         $this->build($config);

--- a/src/GraphQL/DataObjectType/ObjectMetadataType.php
+++ b/src/GraphQL/DataObjectType/ObjectMetadataType.php
@@ -22,7 +22,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Resolver\ObjectMetadata;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
-use Pimcore\Model\DataObject\Fieldcollection\Definition;
+use Pimcore\Model\DataObject\Fieldcollection\Definition as FieldcollectionDefinition;
+use Pimcore\Model\DataObject\Objectbrick\Definition as ObjectbrickDefinition;
 
 class ObjectMetadataType extends ObjectType
 {
@@ -46,10 +47,10 @@ class ObjectMetadataType extends ObjectType
         $this->setGraphQLService($graphQlService);
         $this->class = $class;
         $this->fieldDefinition = $fieldDefinition;
-        if ($class instanceof Definition) {
-            $config['name'] = 'fieldcollection_' . $class->getKey() . '_' . $fieldDefinition->getName();
-        } elseif ($class instanceof \Pimcore\Model\DataObject\Objectbrick\Definition) {
+        if ($class instanceof ObjectbrickDefinition) {
             $config['name'] = 'objectbrick_' . $class->getKey() . '_' . $fieldDefinition->getName();
+        } elseif ($class instanceof FieldcollectionDefinition) {
+            $config['name'] = 'fieldcollection_' . $class->getKey() . '_' . $fieldDefinition->getName();
         } else {
             $config['name'] = 'object_' . $class->getName() . '_' . $fieldDefinition->getName();
         }


### PR DESCRIPTION
Noticed in #449
Fix for 1.1 branch

- ObjectbrickDefinition extends FieldcollectionDefinition. So it must checked first.
- FieldcollectionDefinition has a getKey and not a getName method