### PR TITLE
[Bug]: Get Listing not working with commas in object keys

### DIFF
--- a/doc/10_GraphQL/04_Query/05_DataObject_Queries.md
+++ b/doc/10_GraphQL/04_Query/05_DataObject_Queries.md
@@ -86,8 +86,39 @@ Base structure for getting a list of data objects, restricted by IDs:
 ```graphql
 {
   getNewsListing(ids: "4,5") {
-    edges {
+     edges {
     ...
+```
+
+Base structure for getting a list of data objects, restricted by fullpath:
+
+```graphql
+{
+  getNewsListing(fullpaths: "/NewsArticle,/NewsArticle2") {
+    totalCount
+    edges {
+      node {
+        id        
+      }
+    }
+  }
+}
+```
+
+Sometimes it can happen that the fullpath already contains a comma. To make sure the comma is not
+interpreted as a list separator in this case, you can quote the path:
+
+```graphql
+{
+  getNewsListing(fullpaths: "'/NewsArticle,Headline','/NewsArticle2'") {
+    totalCount
+    edges {
+      node {
+        id        
+      }
+    }
+  }
+}
 ```
  
  

--- a/src/GraphQL/Resolver/AssetListing.php
+++ b/src/GraphQL/Resolver/AssetListing.php
@@ -116,7 +116,7 @@ class AssetListing
 
                     return $db->quote($fullpath);
                 },
-                str_getcsv($args['fullpaths'], ",", "'")
+                str_getcsv($args['fullpaths'], ',', "'")
             );
             $conditionParts[] = '(concat(path, filename) IN (' . implode(',', $quotedFullpaths) . '))';
         }

--- a/src/GraphQL/Resolver/AssetListing.php
+++ b/src/GraphQL/Resolver/AssetListing.php
@@ -116,7 +116,7 @@ class AssetListing
 
                     return $db->quote($fullpath);
                 },
-                explode(',', $args['fullpaths'])
+                str_getcsv($args['fullpaths'], ",", "'")
             );
             $conditionParts[] = '(concat(path, filename) IN (' . implode(',', $quotedFullpaths) . '))';
         }

--- a/src/GraphQL/Resolver/QueryType.php
+++ b/src/GraphQL/Resolver/QueryType.php
@@ -392,7 +392,7 @@ class QueryType
 
                     return $db->quote($fullpath);
                 },
-                str_getcsv($args['fullpaths'], ",", "'")
+                str_getcsv($args['fullpaths'], ',', "'")
             );
             $conditionParts[] = '(concat(o_path, o_key) IN (' . implode(',', $quotedFullpaths) . '))';
         }

--- a/src/GraphQL/Resolver/QueryType.php
+++ b/src/GraphQL/Resolver/QueryType.php
@@ -392,7 +392,7 @@ class QueryType
 
                     return $db->quote($fullpath);
                 },
-                explode(',', $args['fullpaths'])
+                str_getcsv($args['fullpaths'], ",", "'")
             );
             $conditionParts[] = '(concat(o_path, o_key) IN (' . implode(',', $quotedFullpaths) . '))';
         }


### PR DESCRIPTION
Resolves #475 

You can now use ' quote the paths in the fullpaths option

e.g.

`{
  getNewsListing(fullpaths: "'/NewsArticle','/NewsArticle2'") {
    totalCount
    edges {
      node {
        id        
      }
    }
  }
}
`

- [x] Add documentation