### PR TITLE
[Bug]: Cannot use concatenator on attributes in object bricks because of null value exception.

### DIFF
--- a/src/GraphQL/Query/Operator/Concatenator.php
+++ b/src/GraphQL/Query/Operator/Concatenator.php
@@ -47,6 +47,9 @@ class Concatenator extends AbstractOperator
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 
             $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);
+            if($childResult == null) {
+                continue;
+            }
             $childValues = $childResult->value;
             if ($childValues && !is_array($childValues)) {
                 $childValues = [$childValues];

--- a/src/GraphQL/Query/Operator/Concatenator.php
+++ b/src/GraphQL/Query/Operator/Concatenator.php
@@ -47,7 +47,7 @@ class Concatenator extends AbstractOperator
             $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 
             $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);
-            if($childResult == null) {
+            if ($childResult == null) {
                 continue;
             }
             $childValues = $childResult->value;


### PR DESCRIPTION
resolve #556 

This also resolves the null value exception when concatenating with empty values from other data components