### PR TITLE
FQN for Type

### DIFF
--- a/doc/10_GraphQL/04_Query/20_Add_Custom_Query.md
+++ b/doc/10_GraphQL/04_Query/20_Add_Custom_Query.md
@@ -31,7 +31,7 @@ if you need more information on Pimcore's event mechanism.
 
         $operation = [
             'type' => $outputType,
-            'args' => ['itemId' => ['type' => Type::nonNull(Type::int())]],
+            'args' => ['itemId' => ['type' => \GraphQL\Type\Definition\Type::nonNull(Type::int())]],
             'resolve' => function ($source, $args, $context, \GraphQL\Type\Definition\ResolveInfo $info) {
                 // resolve the item using the input parameters. Result will be passed
                 // to the field-level resolvers

--- a/doc/10_GraphQL/07_Mutation/27_Add_Custom_Mutations.md
+++ b/doc/10_GraphQL/07_Mutation/27_Add_Custom_Mutations.md
@@ -24,7 +24,7 @@ if you need more information on Pimcore's event mechanism.
         $operation = [
             'type' => Type::string(),           // the result type
             'args' => [
-                'id' => ['type' => Type::nonNull(Type::int())],
+                'id' => ['type' => Type::nonNull(\GraphQL\Type\Definition\Type::int())],
                 'input' => ['type' => $inputType],
             ], 'resolve' => function ($source, $args, $context, \GraphQL\Type\Definition\ResolveInfo $info) {
                 // do something here


### PR DESCRIPTION
The example mixes FQN and shortcuts for `Type`. I suggest we use FQNs everywhere.