### PR TITLE
[Bug]: Fetching asset in format WebP doesn't work

### DIFF
--- a/doc/10_GraphQL/04_Query/11_Query_Samples/11_Sample_GetAsset.md
+++ b/doc/10_GraphQL/04_Query/11_Query_Samples/11_Sample_GetAsset.md
@@ -8,6 +8,7 @@ Deeplink: [http://pimcore-demo-basic.pim.zone/admin/login/deeplink?asset_4_image
 ### Request
 
 Note that for the fullpath and the base64 encoded data you can specify a thumbnail config.
+You can you the `format` argument to retrieve the values for a specific format like `webp`.
 
 ```
 {
@@ -18,7 +19,7 @@ Note that for the fullpath and the base64 encoded data you can specify a thumbna
     # thumbnail URL for exampleCover config
     assetThumb: fullpath(thumbnail: "exampleCover")
     # thumbnail URL for content config
-    assetThumb2: fullpath(thumbnail: "content")
+    assetThumb2: fullpath(thumbnail: "content", format: "webp")
     resolutions(thumbnail: "content", types: [2,5]) {
         resolution
         url
@@ -54,15 +55,15 @@ Note that for the fullpath and the base64 encoded data you can specify a thumbna
             "getAsset": {
               "id": "4",
               "fullpath": "/Car%20Images/jaguar/auto-automobile-automotive-192499.jpg",
-              "assetThumb": "/Car%20Images/jaguar/image-thumb__4__exampleCover/auto-automobile-automotive-192499.webp",
-              "assetThumb2": "/Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499.webp",
+              "assetThumb": "/Car%20Images/jaguar/4/image-thumb__4__exampleCover/auto-automobile-automotive-192499.jpg",
+              "assetThumb2": "/Car%20Images/jaguar/4/image-thumb__4__content/auto-automobile-automotive-192499.webp",
               "resolutions": [
                 {
-                  "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@2x.webp",
+                  "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@2x.jpg",
                   "resolution": 2
                 },
                 {
-                  "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@5x.webp",
+                  "url": "//Car%20Images/jaguar/image-thumb__4__content/auto-automobile-automotive-192499~-~768w@5x.jpg",
                   "resolution": 5
                 }
               ]

--- a/doc/10_GraphQL/04_Query/11_Query_Samples/11_Sample_GetAsset.md
+++ b/doc/10_GraphQL/04_Query/11_Query_Samples/11_Sample_GetAsset.md
@@ -8,7 +8,7 @@ Deeplink: [http://pimcore-demo-basic.pim.zone/admin/login/deeplink?asset_4_image
 ### Request
 
 Note that for the fullpath and the base64 encoded data you can specify a thumbnail config.
-You can you the `format` argument to retrieve the values for a specific format like `webp`.
+You can use the `format` argument to retrieve the values for a specific format like `webp`.
 
 ```
 {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -459,3 +459,8 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/GraphQL/SharedType/KeyValueType.php
+
+		-
+			message: "#^Call to an undefined method Pimcore\\\\Model\\\\Asset\\:\\:getThumbnail\\(\\)\\.$#"
+			count: 1
+			path: src/GraphQL/FieldHelper/AssetFieldHelper.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -459,8 +459,3 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/GraphQL/SharedType/KeyValueType.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Model\\\\Asset\\:\\:getThumbnail\\(\\)\\.$#"
-			count: 1
-			path: src/GraphQL/FieldHelper/AssetFieldHelper.php

--- a/src/GraphQL/AssetType/AssetType.php
+++ b/src/GraphQL/AssetType/AssetType.php
@@ -105,6 +105,7 @@ class AssetType extends ObjectType
                 'type' => $resolutionsType,
                 'args' => [
                     'thumbnail' => ['type' => Type::nonNull(Type::string())],
+                    'format' => ['type' => Type::string()],
                     'types' => $resolutionsArgumentsType
                 ],
                 'resolve' => [$resolver, 'resolveResolutions'],
@@ -112,7 +113,8 @@ class AssetType extends ObjectType
             'dimensions' => [
                 'type' => $dimensionsType,
                 'args' => [
-                    'thumbnail' => ['type' => Type::string()]
+                    'thumbnail' => ['type' => Type::string()],
+                    'format' => ['type' => Type::string()]
                 ],
                 'resolve' => [$resolver, 'resolveDimensions'],
             ],
@@ -133,6 +135,7 @@ class AssetType extends ObjectType
                 ])),
                 'args' => [
                     'thumbnail' => ['type' => Type::nonNull(Type::string())],
+                    'format' => ['type' => Type::string()]
                 ],
                 'resolve' => [$resolver, 'resolveSrcSet'],
             ],
@@ -143,7 +146,8 @@ class AssetType extends ObjectType
             'data' => [
                 'type' => Type::string(),
                 'args' => [
-                    'thumbnail' => ['type' => Type::string()]
+                    'thumbnail' => ['type' => Type::string()],
+                    'format' => ['type' => Type::string()]
                 ],
                 'resolve' => [$resolver, 'resolveData'],
             ],

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -43,12 +43,16 @@ class AssetFieldHelper extends AbstractFieldHelper
 
     public function getImageDocumentThumbnail(Asset $asset, string | Image\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
     {
+        $thumb = null;
         if ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
             $thumb = $asset->getImageThumbnail($thumbNailConfig);
         } elseif ($asset instanceof Asset\Image) {
             $thumb = $asset->getThumbnail($thumbNailConfig, false);
         }
-        if (isset($thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {
+        if (isset($thumb) &&
+            isset($thumbNailFormat) &&
+            method_exists($thumb, 'getAsFormat') &&
+            !($asset instanceof Asset\Video)) {
             $thumb = $thumb->getAsFormat($thumbNailFormat);
         }
 

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -45,7 +45,7 @@ class AssetFieldHelper extends AbstractFieldHelper
     {
         if ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
             $thumb = $asset->getImageThumbnail($thumbNailConfig);
-        } else {
+        } elseif ($asset instanceof Asset\Image) {
             $thumb = $asset->getThumbnail($thumbNailConfig, false);
         }
         if (isset($thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -43,16 +43,12 @@ class AssetFieldHelper extends AbstractFieldHelper
 
     public function getImageDocumentThumbnail(Asset $asset, string | Image\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
     {
-        $thumb = null;
         if ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
             $thumb = $asset->getImageThumbnail($thumbNailConfig);
         } elseif ($asset instanceof Asset\Image) {
             $thumb = $asset->getThumbnail($thumbNailConfig, false);
         }
-        if (isset($thumb) &&
-            isset($thumbNailFormat) &&
-            method_exists($thumb, 'getAsFormat') &&
-            !($asset instanceof Asset\Video)) {
+        if (isset($thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {
             $thumb = $thumb->getAsFormat($thumbNailFormat);
         }
 

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -45,7 +45,7 @@ class AssetFieldHelper extends AbstractFieldHelper
     {
         if ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
             $thumb = $asset->getImageThumbnail($thumbNailConfig);
-        } elseif ($asset instanceof Asset\Image) {
+        } else {
             $thumb = $asset->getThumbnail($thumbNailConfig, false);
         }
         if (isset($thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -23,6 +23,46 @@ use Pimcore\Model\Asset\Video;
 
 class AssetFieldHelper extends AbstractFieldHelper
 {
+    public function getVideoThumbnail(Asset\Video $asset, string|Video\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed {
+        if (isset($thumbNailFormat) && $thumbNailFormat !== "image") {
+            $value = $asset->getThumbnail($thumbNailConfig);
+            if ($value) {
+                $formats = $value['formats'] ?? [];
+                $format = $formats[$thumbNailFormat] ?? null;
+                if ($format) {
+                    return $format;
+                }
+            }
+        } else {
+            return $asset->getImageThumbnail($thumbNailConfig);
+        }
+        return null;
+    }
+
+    public function getImageDocumentThumbnail(Asset $asset, string|Image\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
+    {
+        if($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
+            $thumb = $asset->getImageThumbnail($thumbNailConfig);
+        }
+        else {
+            $thumb = $asset->getThumbnail($thumbNailConfig, false);
+        }
+        if(isset($thumbNailFormat) && method_exists($thumb, "getAsFormat") && !($asset instanceof Asset\Video)) {
+            $thumb = $thumb->getAsFormat($thumbNailFormat);
+        }
+        return $thumb;
+    }
+
+    public function getAssetThumbnail(Asset $asset, string|Image\Thumbnail\Config|Video\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
+    {
+        if(($asset instanceof Asset\Video) && (is_string($thumbNailConfig) || $thumbNailConfig instanceof Video\Thumbnail\Config)) {
+            return $this->getVideoThumbnail($asset, $thumbNailConfig, $thumbNailFormat);
+        }
+        else {
+            return $this->getImageDocumentThumbnail($asset, $thumbNailConfig, $thumbNailFormat);
+        }
+    }
+
     /**
      * @param FieldNode $ast
      * @param array $data
@@ -43,6 +83,7 @@ class AssetFieldHelper extends AbstractFieldHelper
         $arguments = $this->getArguments($ast);
         $languageArgument = isset($arguments['language']) ? $arguments['language'] : null;
         $thumbnailArgument = isset($arguments['thumbnail']) ? $arguments['thumbnail'] : null;
+        $thumbnailFormat = $arguments['format'] ?? null;
 
         $realName = $astName;
 
@@ -66,8 +107,10 @@ class AssetFieldHelper extends AbstractFieldHelper
                 if ($realName == 'fullpath') {
                     $data[$realName] = $container->getThumbnail($thumbnailArgument);
                 } elseif ($realName == 'data') {
-                    $thumb = $container->getThumbnail($thumbnailArgument, false);
-                    $data[$realName] = stream_get_contents($thumb->getStream());
+                    $thumb = $this->getAssetThumbnail($container, $thumbnailArgument, $thumbnailFormat);
+                    if($thumb) {
+                        $data[$realName] = stream_get_contents($thumb->getStream());
+                    }
                 }
             }
         } else {

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -23,8 +23,9 @@ use Pimcore\Model\Asset\Video;
 
 class AssetFieldHelper extends AbstractFieldHelper
 {
-    public function getVideoThumbnail(Asset\Video $asset, string|Video\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed {
-        if (isset($thumbNailFormat) && $thumbNailFormat !== "image") {
+    public function getVideoThumbnail(Asset\Video $asset, string | Video\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
+    {
+        if (isset($thumbNailFormat) && $thumbNailFormat !== 'image') {
             $value = $asset->getThumbnail($thumbNailConfig);
             if ($value) {
                 $formats = $value['formats'] ?? [];
@@ -36,29 +37,29 @@ class AssetFieldHelper extends AbstractFieldHelper
         } else {
             return $asset->getImageThumbnail($thumbNailConfig);
         }
+
         return null;
     }
 
-    public function getImageDocumentThumbnail(Asset $asset, string|Image\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
+    public function getImageDocumentThumbnail(Asset $asset, string | Image\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
     {
-        if($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
+        if ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
             $thumb = $asset->getImageThumbnail($thumbNailConfig);
-        }
-        else {
+        } else {
             $thumb = $asset->getThumbnail($thumbNailConfig, false);
         }
-        if(isset($thumbNailFormat) && method_exists($thumb, "getAsFormat") && !($asset instanceof Asset\Video)) {
+        if (isset($thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {
             $thumb = $thumb->getAsFormat($thumbNailFormat);
         }
+
         return $thumb;
     }
 
-    public function getAssetThumbnail(Asset $asset, string|Image\Thumbnail\Config|Video\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
+    public function getAssetThumbnail(Asset $asset, string | Image\Thumbnail\Config | Video\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
     {
-        if(($asset instanceof Asset\Video) && (is_string($thumbNailConfig) || $thumbNailConfig instanceof Video\Thumbnail\Config)) {
+        if (($asset instanceof Asset\Video) && (is_string($thumbNailConfig) || $thumbNailConfig instanceof Video\Thumbnail\Config)) {
             return $this->getVideoThumbnail($asset, $thumbNailConfig, $thumbNailFormat);
-        }
-        else {
+        } else {
             return $this->getImageDocumentThumbnail($asset, $thumbNailConfig, $thumbNailFormat);
         }
     }
@@ -108,7 +109,7 @@ class AssetFieldHelper extends AbstractFieldHelper
                     $data[$realName] = $container->getThumbnail($thumbnailArgument);
                 } elseif ($realName == 'data') {
                     $thumb = $this->getAssetThumbnail($container, $thumbnailArgument, $thumbnailFormat);
-                    if($thumb) {
+                    if ($thumb) {
                         $data[$realName] = stream_get_contents($thumb->getStream());
                     }
                 }

--- a/src/GraphQL/Resolver/AssetType.php
+++ b/src/GraphQL/Resolver/AssetType.php
@@ -116,9 +116,10 @@ class AssetType
         $thumbNailFormat = $args['format'] ?? null;
         $assetFieldHelper = $this->getGraphQLService()->getAssetFieldHelper();
 
-        if(!isset($thumbNailConfig)) {
+        if (!isset($thumbNailConfig)) {
             return $asset->getFullPath();
         }
+
         return $assetFieldHelper->getAssetThumbnail($asset, $thumbNailConfig, $thumbNailFormat);
     }
 
@@ -139,10 +140,11 @@ class AssetType
         $thumbNailFormat = $args['format'] ?? null;
         $assetFieldHelper = $this->getGraphQLService()->getAssetFieldHelper();
 
-        if(!isset($thumbNailConfig)) {
+        if (!isset($thumbNailConfig)) {
             return $asset->getStream();
         }
         $thumb = $assetFieldHelper->getAssetThumbnail($asset, $thumbNailConfig, $thumbNailFormat);
+
         return $thumb ? base64_encode(stream_get_contents($thumb->getStream())) : base64_encode(stream_get_contents($asset->getStream()));
     }
 
@@ -229,7 +231,7 @@ class AssetType
             /** @var Asset\Image $asset */
             $asset = $this->getAssetFromValue($value, $context);
             $thumbnail = $assetFieldHelper->getAssetThumbnail($asset, $thumbnailName, $thumbnailFormat);
-            if(isset($thumbnail)) {
+            if (isset($thumbnail)) {
                 $thumbnailConfig = $thumbnail->getConfig();
                 foreach ($types as $type) {
                     $thumbConfigRes = clone $thumbnailConfig;

--- a/src/GraphQL/Resolver/AssetType.php
+++ b/src/GraphQL/Resolver/AssetType.php
@@ -140,7 +140,7 @@ class AssetType
         $assetFieldHelper = $this->getGraphQLService()->getAssetFieldHelper();
 
         if(!isset($thumbNailConfig)) {
-            return $asset->getStream();
+            return base64_encode(stream_get_contents($asset->getStream()));
         }
         $thumb = $assetFieldHelper->getAssetThumbnail($asset, $thumbNailConfig, $thumbNailFormat);
         return $thumb ? base64_encode(stream_get_contents($thumb->getStream())) : base64_encode(stream_get_contents($asset->getStream()));


### PR DESCRIPTION
Resolves #541 

format argument should be working for srcset, resolutions, data and fullpath. 
Please test with a pimcore/pimcore version lower than 10.5 too