### PR TITLE
Replace deprecated ts() function with t()

### DIFF
--- a/src/Resources/public/js/mutationoperator/LocaleSwitcher.js
+++ b/src/Resources/public/js/mutationoperator/LocaleSwitcher.js
@@ -36,7 +36,7 @@ pimcore.plugin.datahub.mutationoperator.localeswitcher = Class.create(pimcore.pl
         var data = [];
         for (var i = 0; i < pimcore.settings.websiteLanguages.length; i++) {
             var language = pimcore.settings.websiteLanguages[i];
-            data.push([language, ts(pimcore.available_languages[language])]);
+            data.push([language, t(pimcore.available_languages[language])]);
         }
 
         var store = new Ext.data.ArrayStore({


### PR DESCRIPTION
ts() is deprecated since Pimcore 6.5.2 https://github.com/pimcore/pimcore/pull/5840
Throws console errors since Pimcore 10.5.0 https://github.com/pimcore/pimcore/pull/12771
Will be removed in Pimcore 11.0.0 https://github.com/pimcore/pimcore/pull/12826