### PR TITLE
Fix: Error when resolutions are used with asset folders

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -454,8 +454,3 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/GraphQL/SharedType/KeyValueType.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Model\\\\Asset\\:\\:getThumbnail\\(\\)\\.$#"
-			count: 1
-			path: src/GraphQL/FieldHelper/AssetFieldHelper.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
         - phpstan-bootstrap.php
     stubFiles:
         - stubs/Asset.stub
+        - stubs/ImageThumbnailTrait.stub
         - stubs/Pdf.stub
 includes:
     - phpstan-baseline.neon

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -43,9 +43,11 @@ class AssetFieldHelper extends AbstractFieldHelper
 
     public function getImageDocumentThumbnail(Asset $asset, string | Image\Thumbnail\Config $thumbNailConfig, string $thumbNailFormat = null): mixed
     {
+        $thumb = null;
+
         if ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
             $thumb = $asset->getImageThumbnail($thumbNailConfig);
-        } else {
+        } elseif ($asset instanceof Asset\Image) {
             $thumb = $asset->getThumbnail($thumbNailConfig, false);
         }
         if (isset($thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {

--- a/src/GraphQL/FieldHelper/AssetFieldHelper.php
+++ b/src/GraphQL/FieldHelper/AssetFieldHelper.php
@@ -50,7 +50,7 @@ class AssetFieldHelper extends AbstractFieldHelper
         } elseif ($asset instanceof Asset\Image) {
             $thumb = $asset->getThumbnail($thumbNailConfig, false);
         }
-        if (isset($thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {
+        if (isset($thumb, $thumbNailFormat) && method_exists($thumb, 'getAsFormat') && !($asset instanceof Asset\Video)) {
             $thumb = $thumb->getAsFormat($thumbNailFormat);
         }
 

--- a/stubs/ImageThumbnailTrait.stub
+++ b/stubs/ImageThumbnailTrait.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Pimcore\Model\Asset\Thumbnail;
+
+/**
+ * @method static getAsFormat(string $format)
+ */
+trait ImageThumbnailTrait
+{
+}


### PR DESCRIPTION
We have a relation which can have folders or images. If I want the resolutions from the images I get an error:
![image](https://user-images.githubusercontent.com/998558/184315322-6efa0c28-9bdd-484a-b848-00f1f45d7527.png)
