### PR TITLE
Fix playground explorer request with predefined query in url

### DIFF
--- a/src/Resources/views/Feature/explorer.html.twig
+++ b/src/Resources/views/Feature/explorer.html.twig
@@ -70,13 +70,28 @@
                 const root = document.getElementById("root");
                 root.classList.add("playgroundIn");
 
-                GraphQLPlayground.init(root, {
+                const url = new URL(window.location.href);
+                let query = url.searchParams.get("query") ?? '';
+
+                let config = {
                     endpoint: "{{ graphQLUrl }}",
-                    headers : {
-                        "{{ tokenHeader }}": new URL(window.location.href).searchParams.get("apikey"),
-                        "X-XSRF-TOKEN"     : getCookie("XSRF-TOKEN"),
-                    },
-                });
+                    headers: {
+                        "{{ tokenHeader }}": url.searchParams.get("apikey"),
+                        "X-XSRF-TOKEN": getCookie("XSRF-TOKEN"),
+                    }
+                };
+
+                if (query) {
+                    query = decodeURIComponent(query);
+                    config.query = query;
+                    config = {
+                        tabs: [
+                            config
+                        ]
+                    };
+                }
+
+                GraphQLPlayground.init(root, config);
             });
         </script>
     </body>


### PR DESCRIPTION
Resolves pimcore/demo#332

# Issue
if the query is passed in the url param then executing query on explorer throws error: "Unexpected token '<',.."
![image](https://user-images.githubusercontent.com/5137917/185436580-beda0c2f-0325-452e-8927-43b9207dc448.png)
