### PR TITLE
Fix: FolderTypes have wrong modificationDate field

### DIFF
--- a/src/GraphQL/AssetType/AssetFolderType.php
+++ b/src/GraphQL/AssetType/AssetFolderType.php
@@ -53,7 +53,7 @@ class AssetFolderType extends FolderType
                 ]
             ],
             'creationDate' => Type::int(),
-            'modificationDateDate' => Type::int(),
+            'modificationDate' => Type::int(),
             'properties' => [
                 'type' => Type::listOf($propertyType),
                 'args' => [

--- a/src/GraphQL/DataObjectType/ObjectFolderType.php
+++ b/src/GraphQL/DataObjectType/ObjectFolderType.php
@@ -51,7 +51,7 @@ class ObjectFolderType extends FolderType
                 'type' => Type::string()
             ],
             'creationDate' => Type::int(),
-            'modificationDateDate' => Type::int(),
+            'modificationDate' => Type::int(),
             'parent' => [
                 'type' => $objectTreeType,
                 'resolve' => [$resolver, 'resolveParent'],

--- a/src/GraphQL/DocumentType/DocumentFolderType.php
+++ b/src/GraphQL/DocumentType/DocumentFolderType.php
@@ -52,7 +52,7 @@ class DocumentFolderType extends FolderType
                     'type' => Type::string()
                 ],
                 'creationDate' => Type::int(),
-                'modificationDateDate' => Type::int(),
+                'modificationDate' => Type::int(),
                 'parent' => [
                     'type' => $documentTree,
                     'resolve' => [$resolver, 'resolveParent'],


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/998558/185571582-5839c500-f0c5-46cb-8f2a-0c7191687753.png)
After:
![image](https://user-images.githubusercontent.com/998558/185571640-c28a8201-8838-43a3-95aa-b5a756bafac7.png)


modificationDateDate is always null
