### PR TITLE
[DOCS] - Update "Customizing the endpoint" page

### DIFF
--- a/doc/10_GraphQL/01_Configuration/15_Customize_Endpoint_URL.md
+++ b/doc/10_GraphQL/01_Configuration/15_Customize_Endpoint_URL.md
@@ -2,7 +2,7 @@
 
 The standard endpoint is
 ```
-/pimcore-graphql-webservices/{configurationname}?apikey={yourApiKey}
+/pimcore-graphql-webservices/{clientname}?apikey={yourApiKey}
 ```
 
 So if your configuration name is _blogdemo_ and your apikey _123456_
@@ -17,11 +17,13 @@ Here is a configuration example showing how to override the standard endpoint:
 ```yml
 # app/config/routing.yml
 
+# Changing URL to the explorer environement
 admin_pimcoredatahub_config:
-    path: /pimcore-datahub-webservices-my-endpoint/explorer/{clientname}
-    defaults: { _controller: PimcoreDataHubBundle:GraphQLExplorer:explorer }
+  path: /pimcore-datahub-webservices-my-endpoint/explorer/{clientname}
+  defaults: { _controller: Pimcore\Bundle\DataHubBundle\Controller\GraphQLExplorerController::explorerAction }
 
+# Changing endoint URL
 admin_pimcoredatahub_webservice:
   path: /pimcore-graphql-webservices-my-endpoint/{clientname}
-  defaults: { _controller: PimcoreDataHubBundle:Webservice:webonyx }
+  defaults: { _controller: Pimcore\Bundle\DataHubBundle\Controller\WebserviceController::webonyxAction }
 ```


### PR DESCRIPTION
The docs to customize an endpoint in the data-hub was not up to date. This should be the new config to achieve this