### PR TITLE
[Task]: Replaced deprecated `Service::getType()` method, fix codeception and phpstan tests

### DIFF
--- a/.github/workflows/codeception_pimcore_x.yml
+++ b/.github/workflows/codeception_pimcore_x.yml
@@ -88,12 +88,12 @@ jobs:
               uses: "ramsey/composer-install@v2"
               with:
                   dependency-versions: "${{ matrix.dependencies }}"
-
-            - name: "Test environment infos"
-              run: |
-                  mysql -e "SELECT VERSION();"
-                  php -i
-                  ./bin/console pimcore:system:requirements:check
+#
+#            - name: "Test environment infos"
+#              run: |
+#                  mysql -e "SELECT VERSION();"
+#                  php -i
+#                  ./bin/console pimcore:system:requirements:check
 
             - name: "Sync Metadata Storage"
               run: |

--- a/.github/workflows/codeception_pimcore_x.yml
+++ b/.github/workflows/codeception_pimcore_x.yml
@@ -23,7 +23,7 @@ env:
     PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
     APP_ENV: test
     PIMCORE_TEST: 1
-    PIMCORE_TEST_DB_DSN: "mysql://root@127.0.0.1:33006/pimcore_test"
+    #PIMCORE_TEST_DB_DSN: "mysql://root@127.0.0.1:33006/pimcore_test"
     PIMCORE_TEST_REDIS_DSN: "redis://127.0.0.1:63379"
 
 jobs:
@@ -31,12 +31,14 @@ jobs:
         name: "Codeception tests"
         runs-on: "ubuntu-20.04"
         continue-on-error: ${{ matrix.experimental }}
+        env:
+            PIMCORE_TEST_DB_DSN: "mysql://root@127.0.0.1:33006/pimcore_test?serverVersion=${{ matrix.server_version }}"
         strategy:
             matrix:
                 include:
-                    - { php-version: 8.0, database: "mariadb:10.7", dependencies: lowest, experimental: false }
-                    - { php-version: 8.1, database: "mariadb:10.7", dependencies: highest, experimental: false }
-                    - { php-version: 8.1, database: "mariadb:10.7", dependencies: highest, pimcore_version: "11.x-dev as 11.0.0", experimental: false }
+                    - { php-version: 8.0, database: "mariadb:10.7.7", server_version: "10.7.7-MariaDB-1:10.7.7+maria~ubu2004", dependencies: lowest, experimental: false }
+                    - { php-version: 8.1, database: "mariadb:10.7.7", server_version: "10.7.7-MariaDB-1:10.7.7+maria~ubu2004", dependencies: highest, experimental: false }
+                    - { php-version: 8.1, database: "mariadb:10.7.7", server_version: "10.7.7-MariaDB-1:10.7.7+maria~ubu2004", dependencies: highest, pimcore_version: "11.x-dev as 11.0.0", experimental: false }
         services:
             redis:
                 image: redis

--- a/src/Configuration/Dao.php
+++ b/src/Configuration/Dao.php
@@ -48,7 +48,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
 
     public const CONFIG_PATH = PIMCORE_CONFIGURATION_DIRECTORY . '/data-hub';
 
-    public function configure()
+    public function configure(): void
     {
         $config = \Pimcore::getContainer()->getParameter('pimcore_data_hub');
 

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ImageGallery.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Helper/ImageGallery.php
@@ -106,7 +106,7 @@ class ImageGallery
                     $data['marker'] = $relation->getMarker();
                     $data['img'] = $image;
                     $data['image'] = $image->getType();
-                    $data['__elementType'] = Service::getType($image);
+                    $data['__elementType'] = Service::getElementType($image);
                     $data['__elementSubtype'] = $image->getType();
                 } else {
                     continue;

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -37,7 +37,7 @@ class Installer extends SettingsStoreAwareInstaller
     /**
      * {@inheritdoc}
      */
-    public function install()
+    public function install(): void
     {
         // create backend permission
         Definition::create(ConfigController::CONFIG_NAME)->setCategory(self::DATAHUB_PERMISSION_CATEGORY)->save();
@@ -70,8 +70,6 @@ class Installer extends SettingsStoreAwareInstaller
         }
 
         parent::install();
-
-        return true;
     }
 
     public function isInstalled(): bool


### PR DESCRIPTION
Replaced deprecated `Service::getType()` method.
Fix codeception and phpstan tests in preparation for Pimcore 11