### PR TITLE
[Task]: Remove `pimcore:system:requirements:check`

### DIFF
--- a/.github/workflows/codeception_pimcore_x.yml
+++ b/.github/workflows/codeception_pimcore_x.yml
@@ -91,7 +91,6 @@ jobs:
               run: |
                   mysql -e "SELECT VERSION();"
                   php -i
-                  ./bin/console pimcore:system:requirements:check
 
             - name: "Sync Metadata Storage"
               run: |


### PR DESCRIPTION
Once https://github.com/pimcore/pimcore/issues/12519 is done in 11.x, this command will be not available out of the box, therefore opening this PR as reminder.
If it is still necessary, please change the PR to add the bundle to require-dev.