### PR TITLE
Bugfix: Support multiple filter conditions.

### DIFF
--- a/src/GraphQL/Helper.php
+++ b/src/GraphQL/Helper.php
@@ -27,7 +27,7 @@ class Helper
 {
     /**
      * @param Listing\Concrete $list
-     * @param \stdClass $filter
+     * @param \stdClass | array $filter
      * @param array $columns
      * @param array $mappingTable
      */


### PR DESCRIPTION
Currently we get an error 
"debugMessage":"get_object_vars(): Argument #1 ($object) must be of type object, array given"
if we have multiple filters defined.

e.g.
```
{
  getRequestListing(filter: "[{\"transferCode\": {\"$like\" :\"%push%\"}} , {\"o_creationDate\" : {\"$gt\" : 1634860800}}]") {
    edges {
      node {
        transferCode
        id
        creationDate
      }
    }
  }
}
```

This PR fixes the error.