### PR TITLE
Bugfix Substring operator - error if child has "isArrayType" not defined

### DIFF
--- a/src/GraphQL/Query/Operator/Substring.php
+++ b/src/GraphQL/Query/Operator/Substring.php
@@ -64,7 +64,7 @@ class Substring extends AbstractOperator
         $valueResolver = $this->getGraphQlService()->buildValueResolverFromAttributes($c);
 
         $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);
-        $isArrayType = $childResult->isArrayType;
+        $isArrayType = $childResult->isArrayType ?? false;
         $childValues = $childResult->value;
         if ($childValues && !$isArrayType) {
             $childValues = [$childValues];

--- a/src/GraphQL/Query/Operator/Substring.php
+++ b/src/GraphQL/Query/Operator/Substring.php
@@ -65,7 +65,7 @@ class Substring extends AbstractOperator
 
         $childResult = $valueResolver->getLabeledValue($element, $resolveInfo);
         $isArrayType = $childResult->isArrayType ?? false;
-        $childValues = $childResult->value;
+        $childValues = $childResult->value ?? null;
         if ($childValues && !$isArrayType) {
             $childValues = [$childValues];
         }
@@ -89,7 +89,7 @@ class Substring extends AbstractOperator
                 $valueArray[] = $childValue;
             }
         } else {
-            $valueArray[] = $childResult->value;
+            $valueArray[] = $childValues;
         }
 
         $result->isArrayType = $isArrayType;


### PR DESCRIPTION
If we have a "Substring" operator and a child 
![image](https://user-images.githubusercontent.com/8791970/216016365-80a1b1fb-62ee-49c1-9c41-3ebc7a80ed51.png)

we get the error

"errors": [
    {
      "debugMessage": "Warning: Undefined property: stdClass::$isArrayType",
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      },
...

This PR fixes this issue