### PR TITLE
[Task] Substitute deprecated set/getObject method

### DIFF
--- a/src/GraphQL/DocumentResolver/Email.php
+++ b/src/GraphQL/DocumentResolver/Email.php
@@ -41,7 +41,7 @@ class Email
         $document = Document::getById($documentId);
 
         if ($document instanceof Document\Link) {
-            $relation = $document->getObject();
+            $relation = $document->getElement();
             if ($relation) {
                 return RelationHelper::processRelation($relation, $this->getGraphQlService(), $args, $context, $resolveInfo);
             }

--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -384,7 +384,7 @@ class MutationType extends ObjectType
                 $type = $value['type'];
                 $id = $value['id'];
                 $target = \Pimcore\Model\Element\Service::getElementById($type, $id);
-                $element->setObject($target);
+                $element->setElement($target);
             } elseif ($key == 'tags') {
                 //skip it to process in callee method
             } elseif ($key == 'href') {


### PR DESCRIPTION
Substitute with `getElement` or `setElement` respectively