### PR TITLE
Fix migration Version20221212152145

### DIFF
--- a/src/Migrations/PimcoreX/Version20221212152145.php
+++ b/src/Migrations/PimcoreX/Version20221212152145.php
@@ -29,11 +29,11 @@ final class Version20221212152145 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('UPDATE pimcore.settings_store SET data=REPLACE(data, \'"childs":\', \'"children":\') WHERE scope=\'pimcore_data_hub\';');
+        $this->addSql('UPDATE settings_store SET data=REPLACE(data, \'"childs":\', \'"children":\') WHERE scope=\'pimcore_data_hub\';');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('UPDATE pimcore.settings_store SET data=REPLACE(data, \'"children":\', \'"childs":\') WHERE scope=\'pimcore_data_hub\';');
+        $this->addSql('UPDATE settings_store SET data=REPLACE(data, \'"children":\', \'"childs":\') WHERE scope=\'pimcore_data_hub\';');
     }
 }


### PR DESCRIPTION
Followup to https://github.com/pimcore/data-hub/pull/646
I got following error:
```
SQLSTATE[42000]: Syntax error or access violation: 1142 UPDATE command denied to user 'db'@'172.31.0.3' for table `pimcore`.`settings_store`
```
Not every database is named 'pimcore'
