### PR TITLE
Fix: Block fields in object bricks are always output as null even though they are filled

### DIFF
--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Block.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Block.php
@@ -88,6 +88,11 @@ class Block extends Base
                 $brickDescriptor = null;
 
                 $brickType = $attributeParts[0];
+                if (strpos($brickType, '?') !== false) {
+                    $brickDescriptor = substr($brickType, 1);
+                    $brickDescriptor = json_decode($brickDescriptor, true);
+                    $brickType = $brickDescriptor['containerKey'];
+                }
                 $brickKey = $attributeParts[1];
 
                 $key = Service::getFieldForBrickType($object->getclass(), $brickType);
@@ -152,8 +157,8 @@ class Block extends Base
                                 $blockDescriptor['__fcType'] = $originalValue['__fcType'];
                                 $blockDescriptor['__itemIdx'] = $originalValue['__itemIdx'];
                             } elseif ($isBrick) {
-                                $blockDescriptor['__brickType'] = $attributeParts[0];
-                                $blockDescriptor['__brickKey'] = $attributeParts[1];
+                                $blockDescriptor['__brickType'] = $brickType;
+                                $blockDescriptor['__brickKey'] = $brickKey;
                             }
 
                             $result[$blockIndex][$localizedDef->getName()] = $blockDescriptor;
@@ -174,8 +179,8 @@ class Block extends Base
                         $blockDescriptor['__fcType'] = $originalValue['__fcType'];
                         $blockDescriptor['__itemIdx'] = $originalValue['__itemIdx'];
                     } elseif ($isBrick) {
-                        $blockDescriptor['__brickType'] = $attributeParts[0];
-                        $blockDescriptor['__brickKey'] = $attributeParts[1];
+                        $blockDescriptor['__brickType'] = $brickType;
+                        $blockDescriptor['__brickKey'] = $brickKey;
                     }
 
                     $result[$blockIndex][$key] = $blockDescriptor;

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Block.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Block.php
@@ -75,6 +75,8 @@ class Block extends Base
             $isBrick = false;
             $attributeParts = explode('~', $attribute);
             $fieldname = $fieldDefinition->getName();
+            $brickType = null;
+            $brickKey = null;
 
             if (count($attributeParts) > 1) {
                 $id = $value['id'];

--- a/src/GraphQL/DataObjectQueryFieldConfigGenerator/Block.php
+++ b/src/GraphQL/DataObjectQueryFieldConfigGenerator/Block.php
@@ -75,6 +75,7 @@ class Block extends Base
             $isBrick = false;
             $attributeParts = explode('~', $attribute);
             $fieldname = $fieldDefinition->getName();
+            $brickDescriptor = null;
             $brickType = null;
             $brickKey = null;
 
@@ -87,7 +88,6 @@ class Block extends Base
                 }
 
                 $context = ['object' => $object];
-                $brickDescriptor = null;
 
                 $brickType = $attributeParts[0];
                 if (strpos($brickType, '?') !== false) {
@@ -159,6 +159,7 @@ class Block extends Base
                                 $blockDescriptor['__fcType'] = $originalValue['__fcType'];
                                 $blockDescriptor['__itemIdx'] = $originalValue['__itemIdx'];
                             } elseif ($isBrick) {
+                                $blockDescriptor['__brickDescriptor'] = $brickDescriptor;
                                 $blockDescriptor['__brickType'] = $brickType;
                                 $blockDescriptor['__brickKey'] = $brickKey;
                             }
@@ -181,6 +182,7 @@ class Block extends Base
                         $blockDescriptor['__fcType'] = $originalValue['__fcType'];
                         $blockDescriptor['__itemIdx'] = $originalValue['__itemIdx'];
                     } elseif ($isBrick) {
+                        $blockDescriptor['__brickDescriptor'] = $brickDescriptor;
                         $blockDescriptor['__brickType'] = $brickType;
                         $blockDescriptor['__brickKey'] = $brickKey;
                     }

--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -986,7 +986,7 @@ class Service
                 }
             } elseif (isset($descriptorData['__brickType']) && $descriptorData['__brickType']) {
                 $context = ['object' => $object];
-                $brickDescriptor = null;
+                $brickDescriptor = $descriptorData['__brickDescriptor'] ?? null;
 
                 $brickType = $descriptorData['__brickType'];
                 $brickKey = $descriptorData['__brickKey'];
@@ -1008,7 +1008,7 @@ class Service
                 }
 
                 if (!empty($key)) {
-                    $blockData = self::getValueForObject($object, $key, $brickType, $brickKey, $def, $context, $brickDescriptor, $args);
+                    $blockData = self::getValueForObject($object, $key, $brickType, $brickKey, $def, $context, $brickDescriptor, $descriptorData['args'] ?? []);
                 }
             } else {
                 $blockGetter = 'get'.ucfirst($descriptorData['__blockName']);


### PR DESCRIPTION
Field config:
```
  -
      attributes:
          attribute: '?{"containerKey":"BrickName","fieldname":"fieldName","brickfield":"blockField"}~blockField'
          label: Test
          dataType: block
      isOperator: false
```

GraphQL Query:
```
{
  getTestClass(id: 123) {
    testDE: test(language: "de") {
      medium
    }
    testEN: test(language: "en") {
      medium
    }
  }
}
```

Output before:
```
{
  "data": {
    "getTestClass": {
      "testDE": null,
      "testEN": null
    }
  }
}
```

Output after first commit:
```
{
  "data": {
    "getTestClass": {
      "testDE": [
        {
          "medium": "Luft"
        }
      ],
      "testEN": [
        {
          "medium": "Luft"
        }
      ]
    }
  }
}
```

Output after last commit:
```
{
  "data": {
    "getTestClass": {
      "testDE": [
        {
          "medium": "Luft"
        }
      ],
      "testEN": [
        {
          "medium": "Air"
        }
      ]
    }
  }
}
```