### PR TITLE
fix: correctly update advanced relation metadata within brick (#761)

### DIFF
--- a/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
@@ -38,7 +38,7 @@ class AdvancedManyToManyObjectRelation extends Base
     public function process($object, $newValue, $args, $context, ResolveInfo $info)
     {
         $attribute = $this->getAttribute();
-        Service::setValue($object, $attribute, function ($container, $setter) use ($newValue, $attribute) {
+        Service::setValue($object, $attribute, function ($container, $setter, $fieldName) use ($newValue) {
             $result = [];
             if (is_array($newValue)) {
                 foreach ($newValue as $newValueItemKey => $newValueItemValue) {
@@ -53,7 +53,7 @@ class AdvancedManyToManyObjectRelation extends Base
                             }
                         }
                         $concrete = Concrete::getById($element->getId());
-                        $item = new ObjectMetadata($attribute, $columns ?? [], $concrete);
+                        $item = new ObjectMetadata($fieldName, $columns ?? [], $concrete);
                         if (isset($data) === true) {
                             $item->setData($data);
                         }

--- a/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyRelation.php
@@ -38,7 +38,7 @@ class AdvancedManyToManyRelation extends Base
     public function process($object, $newValue, $args, $context, ResolveInfo $info)
     {
         $attribute = $this->getAttribute();
-        Service::setValue($object, $attribute, function ($container, $setter) use ($newValue, $attribute) {
+        Service::setValue($object, $attribute, function ($container, $setter, $fieldName) use ($newValue) {
             $result = [];
             if (is_array($newValue)) {
                 foreach ($newValue as $newValueItemKey => $newValueItemValue) {
@@ -52,7 +52,7 @@ class AdvancedManyToManyRelation extends Base
                                 $data[$metaDataValue['name']] = $metaDataValue['value'];
                             }
                         }
-                        $item = new ElementMetadata($attribute, $columns ?? [], $element);
+                        $item = new ElementMetadata($fieldName, $columns ?? [], $element);
                         if (isset($data) === true) {
                             $item->setData($data);
                         }

--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -919,14 +919,14 @@ class Service
                 }
 
                 $innerSetter = 'set' . ucfirst($def->getName());
-                $result = $callback($subBrickType, $innerSetter);
+                $result = $callback($subBrickType, $innerSetter, $def->getName());
 
                 $brickContainer->$subBrickSetter($subBrickType);
 
                 return $result;
             }
         } elseif (method_exists($container, $setter)) {
-            $result = $callback($container, $setter);
+            $result = $callback($container, $setter, $attribute);
         }
 
         return $result;


### PR DESCRIPTION
Error: metadata from an AdvancedManyToManyRelation or AdvancedManyToManyObjectRelation field within a brick wasn't stored
Caused by: ElementMetadata / ObjectMetadata was created with the "brickName~fieldName" notation, instead of the plain "fieldName"
Resolved with: passing the real field name via the callback method

Resolves issue #761 