### PR TITLE
fix: include YouTube/Vimeo id in DocumentElementType\VideoType

### DIFF
--- a/src/GraphQL/DocumentElementType/VideoType.php
+++ b/src/GraphQL/DocumentElementType/VideoType.php
@@ -58,7 +58,12 @@ class VideoType extends ObjectType
                             }
                         ],
                         'id' => [
-                            'type' => Type::int()
+                            'type' => Type::string(),
+                            'resolve' => static function ($value = null, $args = [], $context = [], ResolveInfo $resolveInfo = null) {
+                                if ($value instanceof Video) {
+                                    return $value->getId();
+                                }
+                            }
                         ],
                         'type' => [
                             'type' => Type::string(),


### PR DESCRIPTION
Error: The field was included, but didn't contain a value
Resolved with: Adding a resolve function and changing type to string (as a YouTube id contains non-numeric characters)