### PR TITLE
Fix createAsset mutation failure where tag id expects integer

### DIFF
--- a/src/GraphQL/Traits/ElementTagTrait.php
+++ b/src/GraphQL/Traits/ElementTagTrait.php
@@ -70,7 +70,7 @@ trait ElementTagTrait
         $tags = [];
         foreach ($input as $tag_input) {
             if (isset($tag_input['id']) && $tag_input['id']) {
-                $tag = Tag::getById($tag_input['id']);
+                $tag = Tag::getById((int)$tag_input['id']);
             } elseif (isset($tag_input['path']) && $tag_input['path']) {
                 $tag = Tag::getByPath($tag_input['path']);
             } else {


### PR DESCRIPTION
Fix issue where createAsset mutation fails when supplied a tag id using GraphQL - as per #807 
