### PR TITLE
[Bug][Data loss]: if passing an invalid asset.id, fullpath to object mutation GraphQL query, the assets are silently discarded

### DIFF
--- a/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ElementIdentificationTrait;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Data\ObjectMetadata;
 use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
+use Pimcore\Model\Exception\NotFoundException;
 
 class AdvancedManyToManyObjectRelation extends Base
 {
@@ -58,6 +59,13 @@ class AdvancedManyToManyObjectRelation extends Base
                             $item->setData($data);
                         }
                         $result[] = $item;
+                    } else {
+                        throw new NotFoundException(
+                            sprintf('Element with id %s or fullpath %s not found',
+                                $newValueItemValue['id'],
+                                $newValueItemValue['fullpath']
+                            )
+                        );
                     }
                 }
             }

--- a/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyRelation.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ElementIdentificationTrait;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Data\ElementMetadata;
 use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
+use Pimcore\Model\Exception\NotFoundException;
 
 class AdvancedManyToManyRelation extends Base
 {
@@ -57,6 +58,13 @@ class AdvancedManyToManyRelation extends Base
                             $item->setData($data);
                         }
                         $result[] = $item;
+                    } else {
+                        throw new NotFoundException(
+                            sprintf('Element with id %s or fullpath %s not found',
+                                $newValueItemValue['id'],
+                                $newValueItemValue['fullpath']
+                            )
+                        );
                     }
                 }
             }

--- a/src/GraphQL/DataObjectInputProcessor/ManyToManyObjectRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToManyObjectRelation.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ElementIdentificationTrait;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
+use Pimcore\Model\Exception\NotFoundException;
 
 class ManyToManyObjectRelation extends Base
 {
@@ -50,6 +51,13 @@ class ManyToManyObjectRelation extends Base
 
                     if ($element) {
                         $result[] = $element;
+                    } else {
+                        throw new NotFoundException(
+                            sprintf('Element with id %s or fullpath %s not found',
+                                $newValueItemValue['id'],
+                                $newValueItemValue['fullpath']
+                            )
+                        );
                     }
                 }
             }

--- a/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
@@ -48,7 +48,7 @@ class ManyToManyRelation extends Base
                         $result[] = $element;
                     } else {
                         throw new NotFoundException(
-                            "Doesn't found element: " . $newValueItemValue['fullpath'] ?? $newValueItemValue['id']
+                            "Doesn't found element: " . $newValueItemValue['fullpath']
                         );
                     }
                 }

--- a/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ElementIdentificationTrait;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
+use Pimcore\Model\Exception\NotFoundException;
 
 class ManyToManyRelation extends Base
 {
@@ -45,6 +46,10 @@ class ManyToManyRelation extends Base
 
                     if ($element) {
                         $result[] = $element;
+                    } else {
+                        throw new NotFoundException(
+                            "Doesn't found element: " . $newValueItemValue['fullpath'] ?? $newValueItemValue['id']
+                        );
                     }
                 }
             }

--- a/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToManyRelation.php
@@ -48,7 +48,10 @@ class ManyToManyRelation extends Base
                         $result[] = $element;
                     } else {
                         throw new NotFoundException(
-                            "Doesn't found element: " . $newValueItemValue['fullpath']
+                            sprintf('Element with id %s or fullpath %s not found',
+                                $newValueItemValue['id'],
+                                $newValueItemValue['fullpath']
+                            )
                         );
                     }
                 }

--- a/src/GraphQL/DataObjectInputProcessor/ManyToOneRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToOneRelation.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ElementIdentificationTrait;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
+use Pimcore\Model\Exception\NotFoundException;
 
 class ManyToOneRelation extends Base
 {
@@ -40,8 +41,18 @@ class ManyToOneRelation extends Base
         $me = $this;
         Service::setValue($object, $attribute, function ($container, $setter) use ($newValue) {
             $element = null;
+
             if (is_array($newValue)) {
                 $element = $this->getElementByTypeAndIdOrPath($newValue);
+            }
+
+            if (!$element) {
+                throw new NotFoundException(
+                    sprintf('Element with id %s or fullpath %s not found',
+                        $newValue['id'],
+                        $newValue['fullpath']
+                    )
+                );
             }
 
             return $container->$setter($element);

--- a/src/GraphQL/DataObjectInputProcessor/ManyToOneRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToOneRelation.php
@@ -44,15 +44,15 @@ class ManyToOneRelation extends Base
 
             if (is_array($newValue)) {
                 $element = $this->getElementByTypeAndIdOrPath($newValue);
-            }
-
-            if (!$element) {
-                throw new NotFoundException(
-                    sprintf('Element with id %s or fullpath %s not found',
-                        $newValue['id'],
-                        $newValue['fullpath']
-                    )
-                );
+                    
+                if (!$element) {
+                    throw new NotFoundException(
+                        sprintf('Element with id %s or fullpath %s not found',
+                            $newValue['id'],
+                            $newValue['fullpath']
+                        )
+                    );
+                }
             }
 
             return $container->$setter($element);

--- a/src/GraphQL/DataObjectInputProcessor/ManyToOneRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/ManyToOneRelation.php
@@ -44,7 +44,7 @@ class ManyToOneRelation extends Base
 
             if (is_array($newValue)) {
                 $element = $this->getElementByTypeAndIdOrPath($newValue);
-                    
+
                 if (!$element) {
                     throw new NotFoundException(
                         sprintf('Element with id %s or fullpath %s not found',


### PR DESCRIPTION
resolves #823 