### PR TITLE
Fix: Quantity Value "Warning: Undefined array key value"

### DIFF
--- a/src/GraphQL/DataObjectInputProcessor/QuantityValue.php
+++ b/src/GraphQL/DataObjectInputProcessor/QuantityValue.php
@@ -35,13 +35,17 @@ class QuantityValue extends Base
         $attribute = $this->getAttribute();
         Service::setValue($object, $attribute, function ($container, $setter) use ($newValue) {
             if ($newValue) {
+                $value = null;
                 $unit = null;
+                if (isset($newValue['value'])) {
+                    $value = $newValue['value'];
+                }
                 if (isset($newValue['unitId'])) {
                     $unit = \Pimcore\Model\DataObject\QuantityValue\Unit::getById($newValue['unitId']);
                 } elseif (isset($newValue['unit'])) {
                     $unit = \Pimcore\Model\DataObject\QuantityValue\Unit::getByAbbreviation($newValue['unit']);
                 }
-                $quantityValue = new \Pimcore\Model\DataObject\Data\QuantityValue($newValue['value'], $unit);
+                $quantityValue = new \Pimcore\Model\DataObject\Data\QuantityValue($value, $unit);
 
                 return $container->$setter($quantityValue);
             }


### PR DESCRIPTION
**Context**
When a quantity value, defines no value it raises PHP exception undefined array key "value". 

**Fix**
Applies same behavior as for unit/unitId -> Use null as default

![image](https://github.com/pimcore/data-hub/assets/16246859/e52c2fee-f6d3-47f2-a214-f2c5eecc3395)
