### PR TITLE
Add add all definitions button and multi drag and drop

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -424,8 +424,6 @@ class Configuration extends AbstractModel
     /**
      * @internal
      *
-     * @param ?User $user
-     *
      * @return bool
      */
     public function isAllowed(string $type, ?User $user = null)

--- a/src/Resources/translations/admin.en.yml
+++ b/src/Resources/translations/admin.en.yml
@@ -87,3 +87,4 @@ plugin_pimcore_datahub_disable_introspection: "Disable Introspection"
 plugin_pimcore_datahub_security_introspection_description: "Please note: When introspection is disabled, the autocomplete feature will not work."
 plugin_pimcore_datahub_import: "Import"
 plugin_pimcore_datahub_export: "Export"
+plugin_pimcore_datahub_add_all_definitions: Add all definitions


### PR DESCRIPTION
## Changes in this pull request  
Added a button that adds all definitions except for the system columns.
Furthermore, multi drag and drop has been added with STR + click you can select several fields and drag them over to the configuration.

You can deselect multiple fields and remove them from the configuration again

Button for delete complete configuration fixed

And category selector added ( STR + click ) on a category

## Additional info
https://github.com/user-attachments/assets/e494d937-f23e-4015-ae0a-7e57df561ad4
