### PR TITLE
Fix Warning in Command MigrateLegacyConfig - Undefined array key "list"

### DIFF
--- a/src/Command/Configuration/MigrateLegacyConfig.php
+++ b/src/Command/Configuration/MigrateLegacyConfig.php
@@ -55,7 +55,7 @@ class MigrateLegacyConfig extends AbstractCommand
     private function migrateConfiguration(string $fileName, string $scope): void
     {
         $configs = $this->loadLegacyConfigs($fileName);
-        $configs = $configs['list'];
+        $configs = $configs['list'] ?? [];
         foreach ($configs as $key => $config) {
             $id = $config['general']['name'];
             $this->migrateToSettingsStore((string)$id, $scope, $config);
@@ -63,8 +63,6 @@ class MigrateLegacyConfig extends AbstractCommand
     }
 
     /**
-     *
-     *
      * @return int|null
      *
      * @throws \Exception


### PR DESCRIPTION
`php bin/console datahub:configuration:migrate-legacy-config`

```
In MigrateLegacyConfig.php line 58:
                                       
  Warning: Undefined array key "list"  
                                       

datahub:configuration:migrate-legacy-config

Failed to run php bin/console datahub:configuration:migrate-legacy-config: exit status 1
```