### PR TITLE
Generate static typename for element metadata key value pairs

### DIFF
--- a/src/GraphQL/DataObjectType/ElementMetadataKeyValuePairInputType.php
+++ b/src/GraphQL/DataObjectType/ElementMetadataKeyValuePairInputType.php
@@ -35,7 +35,7 @@ final class ElementMetadataKeyValuePairInputType extends InputObjectType
      */
     public function __construct($config = [])
     {
-        $config['name'] = 'element_metadata_item_' . uniqid();
+        $config['name'] = 'element_metadata_item_key_value_pair_input';
         $this->build($config);
         parent::__construct($config);
     }

--- a/src/GraphQL/DataObjectType/ElementMetadataKeyValuePairType.php
+++ b/src/GraphQL/DataObjectType/ElementMetadataKeyValuePairType.php
@@ -35,7 +35,7 @@ class ElementMetadataKeyValuePairType extends ObjectType
      */
     public function __construct($config = [])
     {
-        $config['name'] = 'element_metadata_item_' . uniqid();
+        $config['name'] = 'element_metadata_item_key_value_pair';
         $this->build($config);
         parent::__construct($config);
     }


### PR DESCRIPTION
Element metadata key/value pairs generate different __typename's on each request. This behavior makes it very hard if you need to work with the type.
This behavior also causes issues with Apollo Router, causing it to return null instead of the value since the typename does not match the loaded super graph.

The response is always the same type, an object with two strings, name and value, so there is no need to generate separate type names on each request.

