### PR TITLE
[Task]: Follow up to `Replace Request::get with explicit input sources`

### DIFF
--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -93,6 +93,7 @@ class WebserviceController extends FrontendController
         LongRunningHelper $longRunningHelper
     ) {
         $clientname = $request->attributes->getString('clientname');
+        $variableValues = null;
 
         $configuration = Configuration::getByName($clientname);
         if (!$configuration || !$configuration->isActive()) {
@@ -161,7 +162,7 @@ class WebserviceController extends FrontendController
         }
 
         $query = $input['query'] ?? '';
-        $variableValues = $input['variables'] ?? null;
+
 
         try {
             $rootValue = [];
@@ -178,7 +179,11 @@ class WebserviceController extends FrontendController
             $this->eventDispatcher->dispatch($event, ExecutorEvents::PRE_EXECUTE);
 
             if ($event->getRequest() instanceof Request) {
-                $variableValues = $event->getRequest()->request->get('variables', $variableValues);
+                $variableValues = $event->getRequest()->request->get('variables');
+            }
+
+            if(empty($variableValues)) {
+                $variableValues = $input['variables'] ?? null;
             }
 
             $configAllowIntrospection = true;

--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -181,7 +181,7 @@ class WebserviceController extends FrontendController
                 $variableValues = $event->getRequest()->request->get('variables');
             }
 
-            if (empty($variableValues)) {
+            if (!$variableValues) {
                 $variableValues = $input['variables'] ?? null;
             }
 

--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -163,7 +163,6 @@ class WebserviceController extends FrontendController
 
         $query = $input['query'] ?? '';
 
-
         try {
             $rootValue = [];
 
@@ -182,7 +181,7 @@ class WebserviceController extends FrontendController
                 $variableValues = $event->getRequest()->request->get('variables');
             }
 
-            if(empty($variableValues)) {
+            if (empty($variableValues)) {
                 $variableValues = $input['variables'] ?? null;
             }
 

--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -178,7 +178,7 @@ class WebserviceController extends FrontendController
             $this->eventDispatcher->dispatch($event, ExecutorEvents::PRE_EXECUTE);
 
             if ($event->getRequest() instanceof Request) {
-                $variableValues = $event->getRequest()->request->get('variables');
+                $variableValues = $event->getRequest()->request->all('variables');
             }
 
             if (!$variableValues) {

--- a/src/GraphQL/DataObjectInputProcessor/Table.php
+++ b/src/GraphQL/DataObjectInputProcessor/Table.php
@@ -46,7 +46,7 @@ class Table extends Base
         $attribute = $this->getAttribute();
         $objectBrickParts = Service::parseObjectBrickFieldName($attribute);
 
-        if(empty($objectBrickParts)) {
+        if (empty($objectBrickParts)) {
             $getter = 'get' . ucfirst($attribute);
             $currentTable = $object->$getter();
         } else {

--- a/tests/GraphQL/ResolveTest.php
+++ b/tests/GraphQL/ResolveTest.php
@@ -38,7 +38,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], []);
 
-        for($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; $i++) {
             $this->assertEquals('translation-k' .$i, $listRes['edges'][$i]['cursor']);
 
             $translation = $listRes['edges'][$i]['node'];
@@ -53,7 +53,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], ['domain' => 'admin']);
 
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $this->assertEquals('translation-ka' .$i, $listRes['edges'][$i]['cursor']);
 
             $translation = $listRes['edges'][$i]['node'];
@@ -85,7 +85,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], ['keys' => $keys]);
 
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $this->assertEquals('translation-k' .$i + 1, $listRes['edges'][$i]['cursor']);
 
             $translation = $listRes['edges'][$i]['node'];
@@ -128,7 +128,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], ['languages' => $languages, 'keys' => $keys]);
 
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $translation = $listRes['edges'][$i]['node'];
             $translations = $translation->getTranslations();
 
@@ -149,10 +149,10 @@ class ResolveTest extends Unit
 
     private function addTranslations(): void
     {
-        for($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; $i++) {
             $this->addTranslation('k' . $i);
         }
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $this->addTranslation('ka' . $i, 'admin');
             $this->addTranslation('ka' . $i, 'admin');
         }

--- a/tests/_support/Helper/Service.php
+++ b/tests/_support/Helper/Service.php
@@ -33,7 +33,7 @@ class Service extends Model
     {
 
         //TODO change this as soon as Pimcore helper as grabService method and requirement is bumped to pimcore/pimcore:10.4
-        if(empty(self::$container)) {
+        if (empty(self::$container)) {
             $container = \Pimcore::getContainer();
             self::$container = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
         }


### PR DESCRIPTION
Part of https://github.com/pimcore/data-hub/issues/679 , see https://github.com/pimcore/data-hub/pull/874

Despite being typed with `mixed`, `Array`can´t be passed as default value for `request->get`, needs to be a scalar value. The type gets checked in the function itself using `is_sclar` and therefore the type mismatch doesnt get detected by phpstan.