### PR TITLE
Fix that empty metadata is filled with the previous relation

### DIFF
--- a/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
@@ -45,6 +45,7 @@ class AdvancedManyToManyObjectRelation extends Base
                     $element = $this->getElementByTypeAndIdOrPath($newValueItemValue);
 
                     if ($element) {
+                        $data = [];
                         $metaData = $newValueItemValue['metadata'] ?? null;
                         if ($metaData) {
                             foreach ($metaData as $metaDataKey => $metaDataValue) {

--- a/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyRelation.php
@@ -45,6 +45,7 @@ class AdvancedManyToManyRelation extends Base
                     $element = $this->getElementByTypeAndIdOrPath($newValueItemValue);
 
                     if ($element) {
+                        $data = [];
                         $metaData = $newValueItemValue['metadata'] ?? null;
                         if ($metaData) {
                             foreach ($metaData as $metaDataKey => $metaDataValue) {

--- a/src/GraphQL/DataObjectInputProcessor/Table.php
+++ b/src/GraphQL/DataObjectInputProcessor/Table.php
@@ -46,7 +46,7 @@ class Table extends Base
         $attribute = $this->getAttribute();
         $objectBrickParts = Service::parseObjectBrickFieldName($attribute);
 
-        if(empty($objectBrickParts)) {
+        if (empty($objectBrickParts)) {
             $getter = 'get' . ucfirst($attribute);
             $currentTable = $object->$getter();
         } else {

--- a/tests/GraphQL/ResolveTest.php
+++ b/tests/GraphQL/ResolveTest.php
@@ -38,7 +38,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], []);
 
-        for($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; $i++) {
             $this->assertEquals('translation-k' .$i, $listRes['edges'][$i]['cursor']);
 
             $translation = $listRes['edges'][$i]['node'];
@@ -53,7 +53,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], ['domain' => 'admin']);
 
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $this->assertEquals('translation-ka' .$i, $listRes['edges'][$i]['cursor']);
 
             $translation = $listRes['edges'][$i]['node'];
@@ -85,7 +85,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], ['keys' => $keys]);
 
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $this->assertEquals('translation-k' .$i + 1, $listRes['edges'][$i]['cursor']);
 
             $translation = $listRes['edges'][$i]['node'];
@@ -128,7 +128,7 @@ class ResolveTest extends Unit
         $translationListing = new TranslationListing($this->service, new EventDispatcher());
         $listRes = $translationListing->resolveListing([], ['languages' => $languages, 'keys' => $keys]);
 
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $translation = $listRes['edges'][$i]['node'];
             $translations = $translation->getTranslations();
 
@@ -149,10 +149,10 @@ class ResolveTest extends Unit
 
     private function addTranslations(): void
     {
-        for($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; $i++) {
             $this->addTranslation('k' . $i);
         }
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $this->addTranslation('ka' . $i, 'admin');
             $this->addTranslation('ka' . $i, 'admin');
         }

--- a/tests/_support/Helper/Service.php
+++ b/tests/_support/Helper/Service.php
@@ -33,7 +33,7 @@ class Service extends Model
     {
 
         //TODO change this as soon as Pimcore helper as grabService method and requirement is bumped to pimcore/pimcore:10.4
-        if(empty(self::$container)) {
+        if (empty(self::$container)) {
             $container = \Pimcore::getContainer();
             self::$container = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
         }


### PR DESCRIPTION
If I update a metadata relation field via data-hub, all metadata fields that not provieded a value (or empty-value) in the promise will reviece the value from the last relation with "filled" metadata.


See:

Before (via Admin):
![image](https://github.com/user-attachments/assets/dede71d7-74d5-435d-a55c-3027f83250d4)

Promise:
![image](https://github.com/user-attachments/assets/fe336194-461e-4096-b523-d2463638a7f5)

After:
![image](https://github.com/user-attachments/assets/08775545-9da0-4fd5-9858-9a1d434e5be5)



