### PR TITLE
Do not store CORS headers in output cache

### DIFF
--- a/doc/10_GraphQL/10_Events.md
+++ b/doc/10_GraphQL/10_Events.md
@@ -230,6 +230,8 @@ class GraphQlSubscriber implements EventSubscriberInterface
 - `OutputCacheEvents::PRE_LOAD`: is triggered before trying to load an entry from cache, if cache is enabled. You can disable the cache  for this request by setting `$event->setUseCache(false)`. If you disable the cache, the entry won't be loaded nor saved
 - `OutputCacheEvents::PRE_SAVE`: if cache is enabled, it's triggered before saving an entry into the cache. You can use it to modify the response before it gets saved.
 
+Uncacheable headers, such as CORS Access-Control-Allow-Origin, are removed from the response before the PRE_SAVE event and re-added after the cached response is loaded.
+
 ```php
 <?php
 

--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -225,17 +225,7 @@ class WebserviceController extends FrontendController
             ];
         }
 
-        $origin = '*';
-        if (!empty($_SERVER['HTTP_ORIGIN'])) {
-            $origin = $_SERVER['HTTP_ORIGIN'];
-        }
-
         $response = new JsonResponse($output);
-        $response->headers->set('Access-Control-Allow-Origin', $origin);
-        $response->headers->set('Access-Control-Allow-Credentials', 'true');
-        $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-        $response->headers->set('Access-Control-Allow-Headers', 'Origin, Content-Type, X-Auth-Token');
-
         $this->cacheService->save($request, $response);
 
         return $response;


### PR DESCRIPTION
Ensure that that dynamic Access-Control-Allow-Origin header is not cached.

- Remove Access-Control-Allow-Origin header before saving to cache
- Add Access-Control-Allow-Origin dynamically when serving cached responses based on the incoming request's Origin

This resolves issue (#895) with CORS headers being cached alongside GraphQL responses, which could cause incorrect Access-Control-Allow-Origin values for clients with different origins.