### PR TITLE
Use factory for Pimcore object type instead static call.

### DIFF
--- a/src/GraphQL/ClassTypeDefinitions.php
+++ b/src/GraphQL/ClassTypeDefinitions.php
@@ -37,12 +37,8 @@ class ClassTypeDefinitions
     {
         $db = Db::get();
         $listing = $db->fetchAllAssociative('SELECT id, name FROM classes');
-
         foreach ($listing as $class) {
-            $id = $class['id'];
-            $name = $class['name'];
-            $objectType = new PimcoreObjectType($graphQlService, $name, $id, [], $context);
-            self::$definitions[$name] = $objectType;
+            self::$definitions[$class['name']] = $graphQlService->buildDataObjectType($class['name'], [], $context);
         }
 
         /**

--- a/src/GraphQL/ClassTypeDefinitions.php
+++ b/src/GraphQL/ClassTypeDefinitions.php
@@ -42,10 +42,9 @@ class ClassTypeDefinitions
         }
 
         /**
-         * @var string $name
          * @var PimcoreObjectType $definition
          */
-        foreach (self::$definitions as $name => $definition) {
+        foreach (self::$definitions as $definition) {
             $definition->build($context);
         }
     }

--- a/src/GraphQL/DataObjectTypeFactory.php
+++ b/src/GraphQL/DataObjectTypeFactory.php
@@ -44,7 +44,13 @@ class DataObjectTypeFactory
     {
         if (!isset(self::$registry[$className])) {
             $class = ClassDefinition::getByName($className);
-            $operatorImpl = new $this->className($this->getGraphQlService(), $className, $class->getId(), $config, $context);
+            $operatorImpl = new $this->className(
+                $this->getGraphQlService(),
+                $className,
+                $class->getId(),
+                $config,
+                $context
+            );
             self::$registry[$className] = $operatorImpl;
         }
 

--- a/src/GraphQL/DataObjectTypeFactory.php
+++ b/src/GraphQL/DataObjectTypeFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\GraphQL;
+
+use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
+use Pimcore\Model\DataObject\ClassDefinition;
+
+class DataObjectTypeFactory
+{
+    use ServiceTrait;
+
+    public static $registry = [];
+
+    /**
+     * @var string
+     */
+    protected $className;
+
+    public function __construct(Service $graphQlService, string $className)
+    {
+        $this->className = $className;
+        $this->setGraphQLService($graphQlService);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function build(string $className, $config = [], $context = [])
+    {
+        if (!isset(self::$registry[$className])) {
+            $class = ClassDefinition::getByName($className);
+            $operatorImpl = new $this->className($this->getGraphQlService(), $className, $class->getId(), $config, $context);
+            self::$registry[$className] = $operatorImpl;
+        }
+
+        return self::$registry[$className];
+    }
+}

--- a/src/GraphQL/DataObjectTypeFactory.php
+++ b/src/GraphQL/DataObjectTypeFactory.php
@@ -26,10 +26,7 @@ class DataObjectTypeFactory
 
     public static $registry = [];
 
-    /**
-     * @var string
-     */
-    protected $className;
+    protected string $className;
 
     public function __construct(Service $graphQlService, string $className)
     {

--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -428,7 +428,6 @@ class Service
     }
 
     /**
-     * @param string $className
      * @param array $config
      * @param array $context
      *
@@ -439,9 +438,8 @@ class Service
     public function buildDataObjectType(string $className, $config = [], $context = [])
     {
         $factory = $this->generalTypeGeneratorFactories->get('object');
-        $result = $factory->build($className, $config, $context);
 
-        return $result;
+        return $factory->build($className, $config, $context);
     }
 
     /**

--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -428,6 +428,23 @@ class Service
     }
 
     /**
+     * @param string $className
+     * @param array $config
+     * @param array $context
+     *
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function buildDataObjectType(string $className, $config = [], $context = [])
+    {
+        $factory = $this->generalTypeGeneratorFactories->get('object');
+        $result = $factory->build($className, $config, $context);
+
+        return $result;
+    }
+
+    /**
      * @param string $typeName
      *
      * @return mixed

--- a/src/Resources/config/graphql.yml
+++ b/src/Resources/config/graphql.yml
@@ -39,6 +39,7 @@ services:
   pimcore.datahub.graphql.dataobjecttype.quantity_value_input: '@Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\QuantityValueInputType'
   pimcore.datahub.graphql.dataobjecttype.input_quantity_value_input: '@Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\InputQuantityValueInputType'
 
+  pimcore.datahub.graphql.dataobjecttype.object: '@Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\PimcoreObjectType'
   pimcore.datahub.graphql.dataobjecttype.object_tree: '@Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\ObjectTreeType'
   pimcore.datahub.graphql.dataobjecttype._object_folder: '@Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\ObjectFolderType'
   pimcore.datahub.graphql.dataobjecttype.asset_metadata_manytoone: '@Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\HrefType'
@@ -84,6 +85,14 @@ services:
       $className: Pimcore\Bundle\DataHubBundle\GraphQL\DocumentType\DocumentTreeType
     tags:
       - { name: pimcore.datahub.graphql.generaltype_factory, id: document_tree }
+
+
+  pimcore.datahub.graphql.generaltype.factory.object:
+    class: Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectTypeFactory
+    arguments:
+      $className: Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType\PimcoreObjectType
+    tags:
+      - { name: pimcore.datahub.graphql.generaltype_factory, id: object }     
 
   pimcore.datahub.graphql.generaltype.factory.object_tree:
     class: Pimcore\Bundle\DataHubBundle\GraphQL\GeneralTypeFactory


### PR DESCRIPTION
Hi,

It looks like Document and Asset have factories that generate QueryType and provide the ability to replace and extend entity schema definitions more easily. However, this does not work for Data Objects.
I suggest adding a similar approach for Data Objects with its own factory, as we need to pass parameters, context, and class names without breaking the current implementation.

Please review.