### PR TITLE
Fix regression from #875

### DIFF
--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -53,7 +53,6 @@ use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Factory;
 use Pimcore\Translation\Translator;
 use Psr\Container\ContainerInterface;
-use stdClass;
 
 class Service
 {
@@ -841,7 +840,7 @@ class Service
      * @param string $attribute
      * @param \Closure $callback
      *
-     * @return stdclass|null
+     * @return mixed result of the callback
      *
      * @throws \Exception
      */

--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -786,7 +786,7 @@ class Service
      * @param array|null $brickDescriptor
      * @param array $args
      *
-     * @return stdclass, value and objectid where the value comes from
+     * @return mixed
      */
     public static function getValueForObject($object, $key, $brickType = null, $brickKey = null, $fieldDefinition = null, $context = [], $brickDescriptor = null, $args = [])
     {
@@ -1167,7 +1167,7 @@ class Service
         string $brickKey,
         ?array $brickDescriptor = null,
         array $descriptorData = [],
-    ): stdClass|array|null {
+    ): mixed {
         $context = ['object' => $object];
 
         $key = \Pimcore\Model\DataObject\Service::getFieldForBrickType($object->getclass(), $brickType);
@@ -1191,7 +1191,8 @@ class Service
                 $def,
                 $context,
                 $brickDescriptor,
-                $descriptorData['args'] ?? []);
+                $descriptorData['args'] ?? []
+            );
         }
 
         return null;

--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -782,6 +782,9 @@ class Service
      * @param string|null $brickType
      * @param string|null $brickKey
      * @param Data|null $fieldDefinition
+     * @param array $context
+     * @param array|null $brickDescriptor
+     * @param array $args
      *
      * @return stdclass, value and objectid where the value comes from
      */
@@ -1162,7 +1165,7 @@ class Service
         Concrete $object,
         string $brickType,
         string $brickKey,
-        string $brickDescriptor = null,
+        ?array $brickDescriptor = null,
         array $descriptorData = [],
     ): stdClass|array|null {
         $context = ['object' => $object];


### PR DESCRIPTION
Followup to #875 and #890

$brickDescriptor is an array. I get following errors:
```
Uncaught TypeError: Pimcore\Bundle\DataHubBundle\GraphQL\Service::getValueFromObjectBrick(): Argument #4 ($brickDescriptor) must be of type ?string, array given
```