### PR TITLE
Allow cloning even if record is not writeable

### DIFF
--- a/src/Resources/public/js/config.js
+++ b/src/Resources/public/js/config.js
@@ -209,7 +209,7 @@ pimcore.plugin.datahub.config = Class.create({
         menu.add(new Ext.menu.Item({
             text: t('clone'),
             iconCls: "pimcore_icon_clone",
-            disabled: !this.userIsAllowedToCreate(record.data.adapter),
+            disabled: !pimcore.settings['data-hub-writeable'] || !this.userIsAllowedToCreate(record.data.adapter),
             handler: this.cloneConfiguration.bind(this, tree, record)
         }));
 

--- a/src/Resources/public/js/config.js
+++ b/src/Resources/public/js/config.js
@@ -209,7 +209,7 @@ pimcore.plugin.datahub.config = Class.create({
         menu.add(new Ext.menu.Item({
             text: t('clone'),
             iconCls: "pimcore_icon_clone",
-            disabled: !record.data['writeable'] || !this.userIsAllowedToCreate(record.data.adapter),
+            disabled: !this.userIsAllowedToCreate(record.data.adapter),
             handler: this.cloneConfiguration.bind(this, tree, record)
         }));
 


### PR DESCRIPTION
The ability to clone does not depends on the source record being  writeable.