### PR TITLE
[Bug]: Cors headers not set when cache was not enabled

### DIFF
--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -33,6 +33,7 @@ use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Bundle\DataHubBundle\Service\CheckConsumerPermissionsService;
 use Pimcore\Bundle\DataHubBundle\Service\FileUploadService;
 use Pimcore\Bundle\DataHubBundle\Service\OutputCacheService;
+use Pimcore\Bundle\DataHubBundle\Service\ResponseServiceInterface;
 use Pimcore\Cache\RuntimeCache;
 use Pimcore\Controller\FrontendController;
 use Pimcore\Helper\LongRunningHelper;
@@ -90,7 +91,8 @@ class WebserviceController extends FrontendController
         LocaleServiceInterface $localeService,
         Factory $modelFactory,
         Request $request,
-        LongRunningHelper $longRunningHelper
+        LongRunningHelper $longRunningHelper,
+        ResponseServiceInterface $responseService
     ) {
         $clientname = $request->attributes->getString('clientname');
         $variableValues = null;
@@ -106,6 +108,8 @@ class WebserviceController extends FrontendController
 
         if ($response = $this->cacheService->load($request)) {
             Logger::debug('Loading response from cache');
+
+            $responseService->addCorsHeaders($response);
 
             return $response;
         }
@@ -226,7 +230,10 @@ class WebserviceController extends FrontendController
         }
 
         $response = new JsonResponse($output);
+
+        $responseService->removeCorsHeaders($response);
         $this->cacheService->save($request, $response);
+        $responseService->addCorsHeaders($response);
 
         return $response;
     }

--- a/src/Service/OutputCacheService.php
+++ b/src/Service/OutputCacheService.php
@@ -71,12 +71,7 @@ class OutputCacheService
 
         $cacheKey = $this->computeKey($request);
 
-        $response = $this->loadFromCache($cacheKey);
-        if ($response) {
-            $this->addCorsHeaders($response);
-        }
-
-        return $response;
+        return $this->loadFromCache($cacheKey);
     }
 
     /**
@@ -89,40 +84,13 @@ class OutputCacheService
             $clientname = $request->attributes->getString('clientname');
             $extraTags = array_merge(['output', 'datahub', $clientname], $extraTags);
 
-            $this->removeCorsHeaders($response);
             $cacheKey = $this->computeKey($request);
 
             $event = new OutputCachePreSaveEvent($request, $response);
             $this->eventDispatcher->dispatch($event, OutputCacheEvents::PRE_SAVE);
 
             $this->saveToCache($cacheKey, $response, $extraTags);
-
-            $this->addCorsHeaders($response);
         }
-    }
-
-    /**
-     * Removes CORS headers including Access-Control-Allow-Origin that should not be cached.
-     */
-    protected function removeCorsHeaders(JsonResponse $response): void
-    {
-        $response->headers->remove('Access-Control-Allow-Origin');
-        $response->headers->remove('Access-Control-Allow-Credentials');
-        $response->headers->remove('Access-Control-Allow-Methods');
-        $response->headers->remove('Access-Control-Allow-Headers');
-    }
-
-    protected function addCorsHeaders(JsonResponse $response): void
-    {
-        $origin = '*';
-        if (!empty($_SERVER['HTTP_ORIGIN'])) {
-            $origin = $_SERVER['HTTP_ORIGIN'];
-        }
-
-        $response->headers->set('Access-Control-Allow-Origin', $origin);
-        $response->headers->set('Access-Control-Allow-Credentials', 'true');
-        $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-        $response->headers->set('Access-Control-Allow-Headers', 'Origin, Content-Type, X-Auth-Token');
     }
 
     /**

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -17,14 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\DataHubBundle\Service;
 
-use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\OutputCachePreLoadEvent;
-use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\OutputCachePreSaveEvent;
-use Pimcore\Bundle\DataHubBundle\Event\GraphQL\OutputCacheEvents;
-use Pimcore\Logger;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 /** @internal */
 final class ResponseService implements ResponseServiceInterface

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Service;
+
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\OutputCachePreLoadEvent;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\Model\OutputCachePreSaveEvent;
+use Pimcore\Bundle\DataHubBundle\Event\GraphQL\OutputCacheEvents;
+use Pimcore\Logger;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/** @internal */
+final class ResponseService implements ResponseServiceInterface
+{
+    /**
+     * Removes CORS headers including Access-Control-Allow-Origin that should not be cached.
+     */
+    public function removeCorsHeaders(JsonResponse $response): void
+    {
+        $response->headers->remove('Access-Control-Allow-Origin');
+        $response->headers->remove('Access-Control-Allow-Credentials');
+        $response->headers->remove('Access-Control-Allow-Methods');
+        $response->headers->remove('Access-Control-Allow-Headers');
+    }
+
+    public function addCorsHeaders(JsonResponse $response): void
+    {
+        $origin = '*';
+        if (!empty($_SERVER['HTTP_ORIGIN'])) {
+            $origin = $_SERVER['HTTP_ORIGIN'];
+        }
+
+        $response->headers->set('Access-Control-Allow-Origin', $origin);
+        $response->headers->set('Access-Control-Allow-Credentials', 'true');
+        $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+        $response->headers->set('Access-Control-Allow-Headers', 'Origin, Content-Type, X-Auth-Token');
+    }
+}

--- a/src/Service/ResponseServiceInterface.php
+++ b/src/Service/ResponseServiceInterface.php
@@ -23,5 +23,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 interface ResponseServiceInterface
 {
     public function removeCorsHeaders(JsonResponse $response): void;
+
     public function addCorsHeaders(JsonResponse $response): void;
 }

--- a/src/Service/ResponseServiceInterface.php
+++ b/src/Service/ResponseServiceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Service;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/** @internal  */
+interface ResponseServiceInterface
+{
+    public function removeCorsHeaders(JsonResponse $response): void;
+    public function addCorsHeaders(JsonResponse $response): void;
+}


### PR DESCRIPTION
Resolves #923 
Follow up to #896 

Decoupled adding/removing cors header from output cache to use both services independently.