### PR TITLE
Improve GraphQL caching for large queries

### DIFF
--- a/src/Service/OutputCacheService.php
+++ b/src/Service/OutputCacheService.php
@@ -111,7 +111,9 @@ class OutputCacheService
      */
     protected function saveToCache($key, $item, $tags = []): void
     {
-        \Pimcore\Cache::save($item, $key, $tags, $this->lifetime);
+        # Increase priority to 1 to make it less likely this cache item is evicted from the
+        # queue before actually being written
+        \Pimcore\Cache::save($item, $key, $tags, $this->lifetime, 1);
     }
 
     private function computeKey(Request $request): string


### PR DESCRIPTION
Pimcore limits caching to a maximum of 50 items per request. For large GraphQL queries, this limit can easily be exceeded because every object loaded during query resolution is added to the cache queue with priority 0. When the queue is truncated, only the top 50 items (by priority) are retained.

This commit increases the priority of the final GraphQL query result, ensuring this is more likely to be cached despite the 50-item limit.