### PR TITLE
Fix translation keys filter

### DIFF
--- a/src/GraphQL/Resolver/TranslationListing.php
+++ b/src/GraphQL/Resolver/TranslationListing.php
@@ -61,8 +61,9 @@ class TranslationListing
 
         if (!empty($args['keys'])) {
             $keysArray = explode(',', $args['keys']);
-            $keysString = "'" . implode("','", $keysArray) . "'" ;
-            $list->setCondition('translations_messages.key IN (' . $keysString . ')');
+            $keysArray = array_map(fn($value): string => $list->quote($value), $keysArray);
+            $keysString = implode(",", $keysArray);
+            $list->setCondition('`key` IN (' . $keysString . ')');
         }
 
         if (!empty($args['languages'])) {

--- a/src/GraphQL/Resolver/TranslationListing.php
+++ b/src/GraphQL/Resolver/TranslationListing.php
@@ -61,8 +61,8 @@ class TranslationListing
 
         if (!empty($args['keys'])) {
             $keysArray = explode(',', $args['keys']);
-            $keysArray = array_map(fn($value): string => $list->quote($value), $keysArray);
-            $keysString = implode(",", $keysArray);
+            $keysArray = array_map(fn ($value): string => $list->quote($value), $keysArray);
+            $keysString = implode(',', $keysArray);
             $list->setCondition('`key` IN (' . $keysString . ')');
         }
 


### PR DESCRIPTION
fix queries like the following: 

```
# Write your query or mutation here
{ getTranslationListing(first:10 domain:"admin" keys:"1960,1961") {
  edges { 
  node { 
  	key
    domain
    translations 
  }
  }
}
}
```