### PR TITLE
Allow setting Date and DateTime-fields to empty / null even if the fieldtype is DATETIME

### DIFF
--- a/src/GraphQL/DataObjectInputProcessor/Date.php
+++ b/src/GraphQL/DataObjectInputProcessor/Date.php
@@ -35,10 +35,17 @@ class Date extends Base
     {
         $attribute = $this->getAttribute();
         Service::setValue($object, $attribute, function ($container, $setter) use ($newValue) {
-            if (!is_numeric($newValue)) {
-                $newValue = strtotime($newValue);
+
+            if ($newValue === '') {
+                $newValue = null;
             }
-            $newValue = Carbon::createFromTimestamp($newValue);
+
+            if (!is_null($newValue)) {
+                if (!is_numeric($newValue)) {
+                    $newValue = strtotime($newValue);
+                }
+                $newValue = Carbon::createFromTimestamp($newValue);
+            }
 
             return $container->$setter($newValue);
         });


### PR DESCRIPTION
Currently, Date or DateTime fields to which zero or an empty string is passed behave differently depending on whether BIGINT or DATETIME is specified as the FieldType. For the latter, it is not possible to set the date empty via graphql. Instead, the date is set to “1970-01-01 01:00:00” in this case.

![grafik](https://github.com/user-attachments/assets/647d2e00-7f36-4308-b577-9f789eaa7eaa)

To solve this issue, it is now checked if the value pasased via graphql is an empty string or null.
