### PR TITLE
[Fix]: advancedManyToManyRelation input metadata fix

### DIFF
--- a/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
+++ b/src/GraphQL/DataObjectInputProcessor/AdvancedManyToManyObjectRelation.php
@@ -42,6 +42,7 @@ class AdvancedManyToManyObjectRelation extends Base
             $result = [];
             if (is_array($newValue)) {
                 foreach ($newValue as $newValueItemKey => $newValueItemValue) {
+                    $columns = [];
                     $element = $this->getElementByTypeAndIdOrPath($newValueItemValue);
 
                     if ($element) {
@@ -54,7 +55,7 @@ class AdvancedManyToManyObjectRelation extends Base
                             }
                         }
                         $concrete = Concrete::getById($element->getId());
-                        $item = new ObjectMetadata($fieldName, $columns ?? [], $concrete);
+                        $item = new ObjectMetadata($fieldName, $columns, $concrete);
                         if ($data !== []) {
                             $item->setData($data);
                         }


### PR DESCRIPTION
When adding multiple elements with metadata to advancedManyToManyObjectRelation 
$columns array was never cleared which resulted in failed request, since $columns would also contain metadata from previous iterations.