### PR TITLE
Drop legacy check for Symfony 4 and use constants in return

### DIFF
--- a/src/Command/Configuration/MigrateLegacyConfig.php
+++ b/src/Command/Configuration/MigrateLegacyConfig.php
@@ -17,7 +17,6 @@ namespace Pimcore\Bundle\DataHubBundle\Command\Configuration;
 
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Model\Tool\SettingsStore;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -63,17 +62,14 @@ class MigrateLegacyConfig extends AbstractCommand
     }
 
     /**
-     * @return int|null
+     * @return int
      *
      * @throws \Exception
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->migrateConfiguration('datahub-configurations.php', 'pimcore_data_hub');
-        if (defined('Symfony\Component\Console\Command\Command::SUCCESS')) {
-            return Command::SUCCESS;
-        } else {
-            return 0;
-        }
+
+        return self::SUCCESS;
     }
 }

--- a/src/Command/Configuration/RebuildWorkspacesCommand.php
+++ b/src/Command/Configuration/RebuildWorkspacesCommand.php
@@ -18,7 +18,6 @@ namespace Pimcore\Bundle\DataHubBundle\Command\Configuration;
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
 use Pimcore\Console\AbstractCommand;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,7 +40,7 @@ class RebuildWorkspacesCommand extends AbstractCommand
     /**
      *
      *
-     * @return int|null
+     * @return int
      *
      * @throws \Exception
      */
@@ -76,10 +75,6 @@ class RebuildWorkspacesCommand extends AbstractCommand
             }
         }
 
-        if (defined('Symfony\Component\Console\Command\Command::SUCCESS')) {
-            return Command::SUCCESS;
-        } else {
-            return 0;
-        }
+        return self::SUCCESS;
     }
 }

--- a/src/Command/GraphQL/RebuildDefinitionsCommand.php
+++ b/src/Command/GraphQL/RebuildDefinitionsCommand.php
@@ -44,7 +44,7 @@ class RebuildDefinitionsCommand extends AbstractCommand
      *
      * @throws \Exception
      *
-     *@deprecated Use Pimcore\Bundle\DataHubBundle\Command\Configuration\RebuildWorkspacesCommand instead.
+     * @deprecated Use Pimcore\Bundle\DataHubBundle\Command\Configuration\RebuildWorkspacesCommand instead.
      *
      */
     public function execute(InputInterface $input, OutputInterface $output)
@@ -76,11 +76,6 @@ class RebuildDefinitionsCommand extends AbstractCommand
 
         $this->output->writeln('done');
 
-        if (defined('Symfony\Component\Console\Command\Command::SUCCESS')) {
-            return Command::SUCCESS;
-        } else {
-            //TODO remove this as soon as support for Symfony 4 gets dropped
-            return 0;
-        }
+        return self::SUCCESS;
     }
 }

--- a/src/Command/GraphQL/RebuildDefinitionsCommand.php
+++ b/src/Command/GraphQL/RebuildDefinitionsCommand.php
@@ -17,7 +17,6 @@ namespace Pimcore\Bundle\DataHubBundle\Command\GraphQL;
 
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Console\AbstractCommand;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
hi!

Just small fix and clean up commands. Removed checking  constant and a bit adjust how it's used - it's public constant and might be no require import \Symfony\Component\Console\Command\Command. 

Additionally, removed null from return type in doctypes.  

Please review,