### PR TITLE
[fix] wrong init $rootValue value

### DIFF
--- a/src/Controller/WebserviceController.php
+++ b/src/Controller/WebserviceController.php
@@ -168,7 +168,7 @@ class WebserviceController extends FrontendController
         $query = $input['query'] ?? '';
 
         try {
-            $rootValue = [];
+            $rootValue = null;
 
             $validators = null;
 


### PR DESCRIPTION
This $rootValue var is initiated with an empty array, I don't know why.
That variable has null default value in all function definition using it.

In my case an error occured using api-platform/core bundle [api-platform/core](https://github.com/api-platform/core) which uses webonyx/graphql-php bundle (also used by pimcore-datahub bundle). And api-platform correctly assumes that $rootValue will be null by default.