### PR TITLE
[fix] no 'update' perm needed for 'create' dataobject operation

### DIFF
--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -628,7 +628,7 @@ class MutationType extends ObjectType
                             $newInstance->setType($args['type']);
                         }
 
-                        $resolver = $me->getUpdateObjectResolver($processors, $localeService, $newInstance, $me->omitPermissionCheck);
+                        $resolver = $me->getUpdateObjectResolver($processors, $localeService, $newInstance, true);
 
                         $returnValue = call_user_func_array($resolver, [$value, $args, $context, $info]);
                         if (isset($returnValue['success']) === true &&


### PR DESCRIPTION
Here is a clean PR from my previous here (cause I messed up that one): #969

Hope it'll work this time :D