### PR TITLE
Added system field "key" as optional argument for data object mutation

### DIFF
--- a/doc/01_Installation_and_Upgrade/01_Upgrade_Notes.md
+++ b/doc/01_Installation_and_Upgrade/01_Upgrade_Notes.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 2.2.0
+- [MutationType] Added system field `key` as an optional argument for data object mutation
+
 ## 2.0.0
 
 - [General] Marked several classes as internal and/or final.

--- a/src/GraphQL/Mutation/MutationType.php
+++ b/src/GraphQL/Mutation/MutationType.php
@@ -726,6 +726,7 @@ final class MutationType extends ObjectType
                     'type' => $updateResultType,
                     'args' => [
                         'id' => ['type' => Type::int()],
+                        'key' => ['type' => Type::string()],
                         'fullpath' => ['type' => Type::string()],
                         'parentId' => ['type' => Type::int()],
                         'defaultLanguage' => ['type' => Type::string()],
@@ -880,6 +881,16 @@ final class MutationType extends ObjectType
 
                 if (isset($args['omitMandatoryCheck'])) {
                     $object->setOmitMandatoryCheck($args['omitMandatoryCheck']);
+                }
+
+                if (isset($args['key'])) {
+                    if (!DataObject\Service::isValidKey($args['key'], AbstractObject::OBJECT_TYPE_OBJECT)) {
+                        return [
+                            'success' => false,
+                            'message' => '"key" is not valid',
+                        ];
+                    }
+                    $object->setKey($args['key']);
                 }
 
                 $tags = [];


### PR DESCRIPTION
The field "key" is a system field and should be treated the same way during both creation and updating. While it's possible to add the "key" field to the mutation configuration, this would mean that during creation, "key" would exist both as a parameter and a field on the input object, which can be confusing. In the update case, it would only be available as a field on the input object. Since "key" is required during creation, the parameter must be kept.