### PR TITLE
Symfony7 next steps

### DIFF
--- a/src/Command/Configuration/MigrateLegacyConfig.php
+++ b/src/Command/Configuration/MigrateLegacyConfig.php
@@ -14,6 +14,7 @@ namespace Pimcore\Bundle\DataHubBundle\Command\Configuration;
 
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Model\Tool\SettingsStore;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,13 +22,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
+#[AsCommand(
+    name: 'datahub:configuration:migrate-legacy-config',
+    description: 'Migrate legacy configurations (datahub-configurations.php) to YAML or settings store, depending on your configuration.'
+)]
 final class MigrateLegacyConfig extends AbstractCommand
 {
     protected function configure(): void
     {
-        $this
-            ->setName('datahub:configuration:migrate-legacy-config')
-            ->setDescription('Migrate legacy configurations (datahub-configurations.php) to YAML or settings store, depending on your configuration.');
+        // Configuration moved to AsCommand attribute
     }
 
     private function loadLegacyConfigs(string $fileName): array
@@ -63,11 +66,9 @@ final class MigrateLegacyConfig extends AbstractCommand
     }
 
     /**
-     * @return int|null
-     *
      * @throws \Exception
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->migrateConfiguration('datahub-configurations.php', 'pimcore_data_hub');
         if (defined('Symfony\Component\Console\Command\Command::SUCCESS')) {

--- a/src/Command/Configuration/RebuildWorkspacesCommand.php
+++ b/src/Command/Configuration/RebuildWorkspacesCommand.php
@@ -12,40 +12,38 @@
 
 namespace Pimcore\Bundle\DataHubBundle\Command\Configuration;
 
-use Pimcore\Bundle\DataHubBundle\Configuration;
-use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
 use Pimcore\Console\AbstractCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
+use Pimcore\Bundle\DataHubBundle\Configuration;
 use Symfony\Component\Console\Input\InputOption;
+use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
  */
+#[AsCommand(
+    name: 'datahub:configuration:rebuild-workspaces',
+    description: 'Migrate workspaces from configuration files to database.'
+)]
 final class RebuildWorkspacesCommand extends AbstractCommand
 {
     protected function configure(): void
     {
-        $this
-            ->setName('datahub:configuration:rebuild-workspaces')
-            ->setDescription('Migrate workspaces from configuration files to database.')
-            ->addOption(
-                'configs',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Comma separated list of configurations'
-            );
+        $this->addOption(
+            'configs',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Comma separated list of configurations'
+        );
     }
 
     /**
-     *
-     *
-     * @return int|null
-     *
      * @throws \Exception
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $list = [];
         $options = $input->getOption('configs');

--- a/src/Command/Configuration/RebuildWorkspacesCommand.php
+++ b/src/Command/Configuration/RebuildWorkspacesCommand.php
@@ -12,13 +12,13 @@
 
 namespace Pimcore\Bundle\DataHubBundle\Command\Configuration;
 
-use Pimcore\Console\AbstractCommand;
-use Symfony\Component\Console\Command\Command;
 use Pimcore\Bundle\DataHubBundle\Configuration;
-use Symfony\Component\Console\Input\InputOption;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
+use Pimcore\Console\AbstractCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -12,7 +12,6 @@
 
 namespace Pimcore\Bundle\DataHubBundle\Controller;
 
-use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Bundle\DataHubBundle\ConfigEvents;
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Bundle\DataHubBundle\Event\AdminEvents;
@@ -23,6 +22,7 @@ use Pimcore\Bundle\DataHubBundle\Service\ExportService;
 use Pimcore\Bundle\DataHubBundle\Service\ImportService;
 use Pimcore\Bundle\DataHubBundle\WorkspaceHelper;
 use Pimcore\Controller\Traits\JsonHelperTrait;
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Model\Exception\ConfigWriteException;
 use Pimcore\Model\User;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -12,6 +12,7 @@
 
 namespace Pimcore\Bundle\DataHubBundle\Controller;
 
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Bundle\DataHubBundle\ConfigEvents;
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Bundle\DataHubBundle\Event\AdminEvents;
@@ -377,7 +378,7 @@ class ConfigController extends \Pimcore\Controller\UserAwareController
 
         try {
             $data = $request->request->getString('data');
-            $modificationDate = $request->request->getInt('modificationDate', 0);
+            $modificationDate = ParameterBagHelper::getInt($request->request, 'modificationDate', 0);
 
             $dataDecoded = json_decode($data, true);
 

--- a/src/GraphQL/AssetType/AssetTreeType.php
+++ b/src/GraphQL/AssetType/AssetTreeType.php
@@ -20,8 +20,8 @@ use GraphQL\Type\Definition\UnionType;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Asset;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/AssetType/AssetTreeType.php
+++ b/src/GraphQL/AssetType/AssetTreeType.php
@@ -17,11 +17,11 @@ use GraphQL\Deferred;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Asset;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/ClassificationstoreType/Feature.php
+++ b/src/GraphQL/ClassificationstoreType/Feature.php
@@ -20,8 +20,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FeatureDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/ClassificationstoreType/Feature.php
+++ b/src/GraphQL/ClassificationstoreType/Feature.php
@@ -16,12 +16,12 @@ use GraphQL\Deferred;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Exception\ClientSafeException;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FeatureDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DataObjectType/AbstractRelationsType.php
+++ b/src/GraphQL/DataObjectType/AbstractRelationsType.php
@@ -16,6 +16,8 @@ use GraphQL\Deferred;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ClassTypeDefinitions;
 use Pimcore\Bundle\DataHubBundle\GraphQL\DocumentType\DocumentType;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
@@ -24,8 +26,6 @@ use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Fieldcollection\Definition;
 use Pimcore\Model\Document;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 abstract class AbstractRelationsType extends UnionType implements ContainerAwareInterface
 {

--- a/src/GraphQL/DataObjectType/AbstractRelationsType.php
+++ b/src/GraphQL/DataObjectType/AbstractRelationsType.php
@@ -24,8 +24,8 @@ use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Fieldcollection\Definition;
 use Pimcore\Model\Document;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 abstract class AbstractRelationsType extends UnionType implements ContainerAwareInterface
 {

--- a/src/GraphQL/DataObjectType/BlockEntryType.php
+++ b/src/GraphQL/DataObjectType/BlockEntryType.php
@@ -14,6 +14,8 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType;
 
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\BlockDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Helper;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
@@ -21,8 +23,6 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Fieldcollection\Definition;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DataObjectType/BlockEntryType.php
+++ b/src/GraphQL/DataObjectType/BlockEntryType.php
@@ -21,8 +21,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Fieldcollection\Definition;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DataObjectType/FieldcollectionType.php
+++ b/src/GraphQL/DataObjectType/FieldcollectionType.php
@@ -18,8 +18,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\FieldcollectionDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Cache\RuntimeCache;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DataObjectType/FieldcollectionType.php
+++ b/src/GraphQL/DataObjectType/FieldcollectionType.php
@@ -14,12 +14,12 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectType;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\FieldcollectionDescriptor;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Cache\RuntimeCache;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DataObjectType/ObjectTreeType.php
+++ b/src/GraphQL/DataObjectType/ObjectTreeType.php
@@ -24,8 +24,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Cache\RuntimeCache;
 use Pimcore\Model\DataObject;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DataObjectType/ObjectTreeType.php
+++ b/src/GraphQL/DataObjectType/ObjectTreeType.php
@@ -17,6 +17,8 @@ use GraphQL\Deferred;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ClassTypeDefinitions;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
@@ -24,8 +26,6 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle;
 use Pimcore\Cache\RuntimeCache;
 use Pimcore\Model\DataObject;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DocumentType/DocumentElementType.php
+++ b/src/GraphQL/DocumentType/DocumentElementType.php
@@ -18,8 +18,8 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal
@@ -28,8 +28,6 @@ final class DocumentElementType extends UnionType implements ContainerAwareInter
 {
     use ContainerAwareTrait;
     use ServiceTrait;
-
-    protected $container;
 
     /**
      * @param array $config

--- a/src/GraphQL/DocumentType/DocumentElementType.php
+++ b/src/GraphQL/DocumentType/DocumentElementType.php
@@ -16,10 +16,10 @@ use GraphQL\Deferred;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
-use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
-use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DocumentType/DocumentTreeType.php
+++ b/src/GraphQL/DocumentType/DocumentTreeType.php
@@ -19,8 +19,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element\ElementInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DocumentType/DocumentTreeType.php
+++ b/src/GraphQL/DocumentType/DocumentTreeType.php
@@ -15,12 +15,12 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\DocumentType;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element\ElementInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DocumentType/DocumentType.php
+++ b/src/GraphQL/DocumentType/DocumentType.php
@@ -16,11 +16,11 @@ use GraphQL\Deferred;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/DocumentType/DocumentType.php
+++ b/src/GraphQL/DocumentType/DocumentType.php
@@ -19,8 +19,8 @@ use GraphQL\Type\Definition\UnionType;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/General/AnyDocumentTargetType.php
+++ b/src/GraphQL/General/AnyDocumentTargetType.php
@@ -14,11 +14,11 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\General;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/General/AnyDocumentTargetType.php
+++ b/src/GraphQL/General/AnyDocumentTargetType.php
@@ -17,8 +17,8 @@ use GraphQL\Type\Definition\UnionType;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/General/AnyTargetType.php
+++ b/src/GraphQL/General/AnyTargetType.php
@@ -14,12 +14,12 @@ namespace Pimcore\Bundle\DataHubBundle\GraphQL\General;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ClassTypeDefinitions;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/General/AnyTargetType.php
+++ b/src/GraphQL/General/AnyTargetType.php
@@ -18,8 +18,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\ClassTypeDefinitions;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/PropertyType/ObjectsType.php
+++ b/src/GraphQL/PropertyType/ObjectsType.php
@@ -16,12 +16,12 @@ use GraphQL\Deferred;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\UnionType;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 use Pimcore\Bundle\DataHubBundle\GraphQL\ClassTypeDefinitions;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
-use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal

--- a/src/GraphQL/PropertyType/ObjectsType.php
+++ b/src/GraphQL/PropertyType/ObjectsType.php
@@ -20,8 +20,8 @@ use Pimcore\Bundle\DataHubBundle\GraphQL\ClassTypeDefinitions;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Traits\ServiceTrait;
 use Pimcore\Model\Document;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal


### PR DESCRIPTION
This pull request makes several improvements to command registration and code consistency, as well as updates to GraphQL type classes for dependency injection. The most significant changes are the migration to Symfony's attribute-based command registration, explicit return type declarations, and the replacement of Symfony's dependency injection interfaces with Pimcore's equivalents in GraphQL type classes.

### Command Registration and Configuration

* Migrated command registration in `MigrateLegacyConfig` and `RebuildWorkspacesCommand` from method-based configuration to the Symfony `AsCommand` attribute, simplifying command definitions. [[1]](diffhunk://#diff-10a07c47b5a19dbbf443702207ff40bb497b4f1711bf6792a129c2a9b5680978R17-R33) [[2]](diffhunk://#diff-ed859b88541781b5cc125400e496a4cff2cdbc1aa884c6f2d81153a3067ff440R27-R35)
* Removed legacy configuration code from the `configure()` methods in both command classes, as configuration is now handled by attributes. [[1]](diffhunk://#diff-10a07c47b5a19dbbf443702207ff40bb497b4f1711bf6792a129c2a9b5680978R17-R33) [[2]](diffhunk://#diff-ed859b88541781b5cc125400e496a4cff2cdbc1aa884c6f2d81153a3067ff440R27-R35)

### Code Consistency and Type Safety

* Updated the `execute` methods in both command classes to explicitly declare `int` as the return type, aligning with Symfony standards and improving type safety. [[1]](diffhunk://#diff-10a07c47b5a19dbbf443702207ff40bb497b4f1711bf6792a129c2a9b5680978L66-R71) [[2]](diffhunk://#diff-ed859b88541781b5cc125400e496a4cff2cdbc1aa884c6f2d81153a3067ff440L42-R46)
* In `ConfigController`, replaced direct request parameter access with `ParameterBagHelper::getInt` for safer integer retrieval.

### Dependency Injection in GraphQL Types

* Replaced usage of `Symfony\Component\DependencyInjection\ContainerAwareInterface` and `ContainerAwareTrait` with Pimcore's equivalents (`Pimcore\Bundle\CoreBundle\DependencyInjection\ContainerAwareInterface` and `ContainerAwareTrait`) across multiple GraphQL type classes for consistency within the Pimcore codebase. [[1]](diffhunk://#diff-e994f852d875469859c40eeef5770891c5352b9fac00decbed0c7dba07e55b5fR20-L24) [[2]](diffhunk://#diff-c708a9eb3f7a86888e53ef424b747c8a9ba54804275f8f4ad8eb855a48b8fe66R19-L24) [[3]](diffhunk://#diff-715f6098352b9bc18dc5b6f2945bf7783b8e71ed2a9b74657b02e189081e1664R19-R20) [[4]](diffhunk://#diff-545245ae229fb9f90af3bd2893660b932929adc496baee21b39a7a2d779d2cf9R17-L25) [[5]](diffhunk://#diff-87f2aa57c3c1ca15112375e87c1267ece0e7d015406cc14dd42b5ff1969d7aa4R17-L22) [[6]](diffhunk://#diff-16220e90e7bde826c711a12f0d3ede213cd1a1a570f07f4c635b7aac11554e9aR20-L28) [[7]](diffhunk://#diff-d1cc2b93acd6e46bc4da00940235f4ce32ddbbc3e3877db85509f8327757857cR19-L22) [[8]](diffhunk://#diff-c78bc038da3685b240d89da2ed4ba792198ceeec866edc4ecda867ba158f8b4cR18-L23) [[9]](diffhunk://#diff-b00ce7fe5864da69470a4fe4a52b749bd06d681284bf2e6df5b1db24ca38465dR19-L23) [[10]](diffhunk://#diff-d9599fed1f097f831ba60fc1ceb3e42e0b6c781f5591d530f5fdac930d9faabaR17-L21) [[11]](diffhunk://#diff-e38764953079647cea8b533b2e941c6fb9440b91e2df95953daf0cac7691e287R17-L22) [[12]](diffhunk://#diff-acb2816106f6fca44d931fd7b66d0d431c591d515cde8fa3e22c84d1496d208bR19-L24)
* Removed redundant property declarations for `$container` in `DocumentElementType`, as the trait now handles this.