### PR TITLE
[Bug]: GraphQL Query returns languages inherited values in object bricks when using getFallbackLanguageValue = false on localized fields 

### DIFF
--- a/src/GraphQL/Service.php
+++ b/src/GraphQL/Service.php
@@ -818,7 +818,11 @@ class Service
                     /** @var Data\Localizedfields $fieldDefinitionLocalizedFields */
                     $fieldDefinitionLocalizedFields = $brickDefinition->getFieldDefinition('localizedfields');
                     $fieldDefinition = $fieldDefinitionLocalizedFields->getFieldDefinition($brickKey);
-                    $value = $localizedFields->getLocalizedValue($brickDescriptor['brickfield'], isset($args['language']) ? $args['language'] : null);
+                    $value = $localizedFields->getLocalizedValue(
+                        $brickDescriptor['brickfield'],
+                        $args['language'] ?? null,
+                        isset($args['getFallbackLanguageValue']) ? !$args['getFallbackLanguageValue'] : false
+                    );
                 } else {
                     $brickFieldGetter = 'get' . ucfirst($brickKey);
                     $value = $value->$brickFieldGetter();
@@ -1022,7 +1026,11 @@ class Service
                 $result = $itemData[$descriptorData['__blockFieldName']]->getData();
 
                 if (isset($descriptorData['__localized']) && $descriptorData['__localized']) {
-                    $result = $result->getLocalizedValue($descriptorData['__localized'], $args['language'] ?? null);
+                    $result = $result->getLocalizedValue(
+                        $descriptorData['__localized'],
+                        $args['language'] ?? null,
+                        isset($args['getFallbackLanguageValue']) ? !$args['getFallbackLanguageValue'] : false
+                    );
                 }
             }
         } elseif (substr($attribute, 0, 1) == '~') {

--- a/tests/_support/Helper/Service.php
+++ b/tests/_support/Helper/Service.php
@@ -15,7 +15,6 @@
 
 namespace Pimcore\Bundle\PimcoreDataHubBundle\Tests\Helper;
 
-use Pimcore\Model\DataObject\Unittest;
 use Pimcore\Tests\Support\Helper\Model;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 


### PR DESCRIPTION
Resolves https://github.com/pimcore/data-hub/issues/1003

Follow up https://github.com/pimcore/data-hub/pull/907

