### PR TITLE
Fix dead links in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We gladly accept community pull requests.
 There are a few necessary steps before we can accept a pull request:
 
 * [Fork us!](https://help.github.com/articles/fork-a-repo/)
-* Select the right branch. main(e.g. 2026.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 1.0)
+* Select the right branch. main(e.g. 2026.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 2026.0)
 * Code! Follow the coding standards defined [here](./.php-cs-fixer.dist.php).
 * [Send a pull request](https://help.github.com/articles/using-pull-requests/) from your fork’s branch to our default branch.
 * [Sign the CLA](https://cla-assistant.io/pimcore/data-hub) - see also below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ We gladly accept community pull requests.
 There are a few necessary steps before we can accept a pull request:
 
 * [Fork us!](https://help.github.com/articles/fork-a-repo/)
-* Select the right branch. main(e.g. 1.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 1.0)
-* Code! Follow the coding standards defined [here](https://github.com/pimcore/data-hub/blob/1.x/.php-cs-fixer.dist.php).
-* [Send a pull request](https://help.github.com/articles/using-pull-requests/) from your fork’s branch to our `master` branch.
+* Select the right branch. main(e.g. 2026.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 1.0)
+* Code! Follow the coding standards defined [here](./.php-cs-fixer.dist.php).
+* [Send a pull request](https://help.github.com/articles/using-pull-requests/) from your fork’s branch to our default branch.
 * [Sign the CLA](https://cla-assistant.io/pimcore/data-hub) - see also below.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We gladly accept community pull requests.
 There are a few necessary steps before we can accept a pull request:
 
 * [Fork us!](https://help.github.com/articles/fork-a-repo/)
-* Select the right branch. main(e.g. 2026.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 2026.0)
+* Select the right branch. main(e.g. 2026.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 2026.1)
 * Code! Follow the coding standards defined [here](./.php-cs-fixer.dist.php).
 * [Send a pull request](https://help.github.com/articles/using-pull-requests/) from your fork’s branch to our default branch.
 * [Sign the CLA](https://cla-assistant.io/pimcore/data-hub) - see also below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ We gladly accept community pull requests.
 There are a few necessary steps before we can accept a pull request:
 
 * [Fork us!](https://help.github.com/articles/fork-a-repo/)
-* Select the right branch. main(e.g. 2026.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 2026.1)
+* Select the right branch. default branch (e.g. 2026.x) for features and improvements or latest maintenance branch for bug fixes (e.g. 2026.2)
 * Code! Follow the coding standards defined [here](./.php-cs-fixer.dist.php).
-* [Send a pull request](https://help.github.com/articles/using-pull-requests/) from your fork’s branch to our default branch.
+* [Send a pull request](https://help.github.com/articles/using-pull-requests/) from your fork’s branch to the branch you selected above.
 * [Sign the CLA](https://cla-assistant.io/pimcore/data-hub) - see also below.
 
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ A short introduction video of an output channel based on the GraphQL query langu
 
 ## Further Information
 On Pimcore Datahub adapters:
-- [Datahub Simple Rest API](https://pimcore.com/docs/platform/Datahub_Simple_Rest/)
-- [Datahub File Export](https://pimcore.com/docs/platform/Datahub_File_Export/)
-- [Datahub Productsup](https://pimcore.com/docs/platform/Datahub_Productsup/)
+- [Datahub Simple Rest API](https://docs.pimcore.com/platform/Datahub_Simple_Rest/)
+- [Datahub File Export](https://docs.pimcore.com/platform/Datahub_File_Export/)
+- [Datahub Productsup](https://docs.pimcore.com/platform/Datahub_Productsup/)
   
 ## Contributions
 As Pimcore Datahub is a community project, any contributions highly appreciated.
-For details see our [Contributing guide](https://github.com/pimcore/data-hub/blob/master/CONTRIBUTING.md).
+For details see our [Contributing guide](./CONTRIBUTING.md).


### PR DESCRIPTION
## Motivation

The README contains links that no longer resolve correctly, mostly because the `master` branch no longer exists and some doc URLs now redirect.

## Changes

### README.md
- **Contributing guide (404):** Linked to `https://github.com/pimcore/data-hub/blob/master/CONTRIBUTING.md`, but the `master` branch no longer exists → **404**. Replaced with a relative link `./CONTRIBUTING.md`, which always resolves against the ref being viewed.
- **Adapter docs (301 redirect):** The three adapter links under *Further Information* used `https://pimcore.com/docs/platform/...`, which 301-redirects to `https://docs.pimcore.com/platform/...`. Updated to the canonical domain.

### CONTRIBUTING.md
- **Branch guidance:** Replaced the stale `1.x` / `1.0` / `master` references. The default branch is now referred to generically (e.g. `2026.x`), the maintenance-branch example points to the current `2026.2`, and PRs are directed to the branch selected above rather than always the default branch.
- **php-cs-fixer link:** Switched to a relative link `./.php-cs-fixer.dist.php`.

All other links (SonarCloud badge, internal `./doc/...` links, GitHub issues, CLA assistant) were verified and are fine.

> **Note:** This PR targets the `2026.1` maintenance branch. The `CONTRIBUTING.md` fixes are therefore part of this PR — they are not yet present on `2026.1` — and will flow upwards to `2026.x` on the next merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
