### PR TITLE
Centralize frontend build/publish on shared reusable workflows

### DIFF
--- a/.github/workflows/frontend-publish-unified.yaml
+++ b/.github/workflows/frontend-publish-unified.yaml
@@ -13,9 +13,6 @@ concurrency:
   group: frontend-publish-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  FALLBACK_TARGET_RELEASE: "2026.3.0"
-
 permissions:
   contents: read
 
@@ -70,6 +67,13 @@ jobs:
         if: steps.check.outputs.publish == 'true'
         shell: bash
         run: |
+          # Tag runs: the reusable workflow derives the release version from the
+          # tag itself, so target-release is unused here — emit a non-empty
+          # placeholder so the publish job still runs.
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "target-release=tag" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Canary base = next release of this branch's line; the branch name
           # (e.g. "2026.x", "2026.2") is itself a valid semver range
           BRANCH="${GITHUB_REF_NAME}"
@@ -81,15 +85,16 @@ jobs:
             else
               TARGET="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( BASH_REMATCH[3] + 1 ))"
             fi
+            echo "Canary target release for ${BRANCH}: ${TARGET}"
+            echo "target-release=${TARGET}" >> "$GITHUB_OUTPUT"
           else
-            TARGET="${FALLBACK_TARGET_RELEASE}"
+            echo "::warning::Could not derive canary release line for ${BRANCH} (pkg=${PKG_NAME}); skipping canary publish."
+            echo "target-release=" >> "$GITHUB_OUTPUT"
           fi
-          echo "Canary target release for ${BRANCH}: ${TARGET}"
-          echo "target-release=${TARGET}" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: gate
-    if: needs.gate.outputs.publish == 'true'
+    if: needs.gate.outputs.publish == 'true' && needs.gate.outputs.target-release != ''
     permissions:
       id-token: write  # Required for OIDC
       contents: write


### PR DESCRIPTION
Aligns data-hub's frontend CI with studio-dashboards-bundle and copilot-bundle by moving build/publish onto the central `pimcore/workflows-collection-public` reusable workflows.

## Changes
- **`studio-frontend-build.yaml`** (new) — builds and commits the studio bundle via the central reusable, on `assets/studio/**` changes.
- **`frontend-publish-unified.yaml`** — rewritten to a **gate + central reusable** pattern:
  - Publishes canaries only when `assets/studio/**` changed; derives the canary base version per branch line at publish time.
  - Explicit `actions/setup-node` for the version-derivation step.
  - **Skips the canary publish when the release line can't be derived** (no static fallback that goes stale / can misversion a canary on a transient npm failure). Tag releases are unaffected — the reusable derives their version from the tag.
- **Deleted** the superseded local workflows: `frontend-build-pr.yaml`, `shared-frontend-build.yaml`, `shared-npm-publish.yaml`.

## Repo-specific values
- `build-output-path: './src/Resources/public/studio/'` — matches this repo's rsbuild output and tracked assets.
- Also replaces `pull_request_target` (fork build with write token) with the safer `pull_request` model, via the central reusable.