### PR TITLE
Studio Frontend Build: scope push trigger to version branches

### DIFF
--- a/.github/workflows/studio-frontend-build.yaml
+++ b/.github/workflows/studio-frontend-build.yaml
@@ -2,6 +2,9 @@ name: "Studio Frontend Build"
 
 on:
   push:
+    branches:
+      - "[0-9]+.x"
+      - "[0-9]+.[0-9]+"
     paths:
       - "assets/studio/**"
       - "src/Resources/public/studio/build/**"


### PR DESCRIPTION
Part of the fleet-wide fix tracked in pimcore/DevOps-Tasks#2.

## Problem
On PRs, Studio Frontend Build shows cancelled `(push)` checks and a red "Some checks were not successful", because the workflow triggers on both `push` and `pull_request` for the same commit, landing in the same concurrency group (`cancel-in-progress` then cancels one).

## Fix
Scope `push` to version branches (which have no PR); keep `pull_request` for all PRs. Each PR then triggers exactly one run — same-repo and fork PRs both build via `pull_request` (so external contributors still see if their change breaks the build), version branches build+commit via push, nothing collides.

Paths are unchanged. Verify post-merge with an `assets/studio/**` PR: one clean run, no cancelled `(push)`.