### PR TITLE
Fix frontend workflows checkout for private-fork PRs

### DIFF
--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -3,6 +3,14 @@ name: "Shared Frontend Build"
 on:
   workflow_call:
 
+env:
+  # Ref for all checkouts. Fork PRs: the fork can be private (partner orgs),
+  # and this repo's GITHUB_TOKEN cannot read it — fetching the fork directly
+  # fails with "Repository not found". Fetch the PR head as mirrored into the
+  # BASE repo (refs/pull/<n>/head) instead; that ref exists for every PR
+  # regardless of fork visibility. Same-repo runs keep the branch tip.
+  CHECKOUT_REF: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && format('refs/pull/{0}/head', github.event.pull_request.number) || github.head_ref || github.ref_name }}
+
 permissions:
   contents: write
 
@@ -14,8 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -41,8 +48,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -60,7 +66,10 @@ jobs:
         working-directory: ./assets/studio
         run: npm run lint-fix
 
+      # Pushing to the PR branch is only possible for same-repo PRs; on fork
+      # PRs (detached refs/pull/<n>/head checkout) skip the auto-commit.
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
             commit_message: Apply eslint-fixer changes
 
@@ -72,8 +81,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -101,8 +109,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -120,7 +127,10 @@ jobs:
         working-directory: ./assets/studio
         run: npm run build
 
+      # Pushing to the PR branch is only possible for same-repo PRs; on fork
+      # PRs (detached refs/pull/<n>/head checkout) skip the auto-commit.
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           file_pattern: './src/Resources/public/studio/'
           commit_message: Automatic frontend build

--- a/.github/workflows/shared-npm-publish.yaml
+++ b/.github/workflows/shared-npm-publish.yaml
@@ -14,7 +14,12 @@ on:
         default: "latest"
 
 env:
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  # Ref for all checkouts. Fork PRs: the fork can be private (partner orgs),
+  # and this repo's GITHUB_TOKEN cannot read it — fetching the fork directly
+  # fails with "Repository not found". Fetch the PR head as mirrored into the
+  # BASE repo (refs/pull/<n>/head) instead; that ref exists for every PR
+  # regardless of fork visibility. Non-PR runs keep the branch/tag name.
+  CHECKOUT_REF: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && format('refs/pull/{0}/head', github.event.pull_request.number) || github.head_ref || github.ref_name }}
 
 jobs:
   install:
@@ -23,8 +28,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -54,8 +58,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache npm dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Problem

`shared-frontend-build.yaml` and `shared-npm-publish.yaml` check out the PR head **directly from the fork** (`repository: ${{ github.event.pull_request.head.repo.full_name }}`). Private forks (partner orgs, e.g. `laticrete-pimcore/data-hub`) are not readable by this repo's `GITHUB_TOKEN`, so the fetch fails with `remote: Repository not found.` and every job dies at Checkout. `frontend-build-pr.yaml` triggers on `pull_request_target`, so every private-fork PR touching the frontend hits this.

Same failure already observed on data-hub-simple-rest: [run 30102786641](https://github.com/pimcore/data-hub-simple-rest/actions/runs/30102786641/job/89513568796?pr=310); same fix as [workflows-collection-public#142](https://github.com/pimcore/workflows-collection-public/pull/142).

## Fix

- New `CHECKOUT_REF` env: fork PRs fetch `refs/pull/<n>/head` from the **base repo** (mirrored there for every PR regardless of fork visibility); same-repo PRs and push/tag runs keep the branch/tag tip exactly as before. The `repository:` override is dropped.
- The two `git-auto-commit` steps (lint fixes, build output) are gated to same-repo contexts: pushing to a fork branch was never possible with this repo's token, and on the detached `refs/pull/<n>/head` checkout the action would fail rather than skip.

## Notes for reviewers

- `shared-npm-publish.yaml` is currently only called from push/tag triggers, where `head.repo` is empty and checkout already fell back to the base repo — fixed anyway for consistency/future-proofing.
- **Security follow-up (out of scope here):** under `pull_request_target`, the lint/check-types/build jobs run fork-controlled code (`npm ci` hooks, npm scripts) while workflow-level `permissions: contents: write` applies and checkout persists the token in `.git/config`. The upstream reusable workflow (`reusable-studio-frontend-build.yaml`) solves this properly (per-job permissions, `persist-credentials: false`, patch-artifact commit flow) — consider migrating these local copies to it.

## Verification

- YAML validated with js-yaml.
- push / dispatch → `CHECKOUT_REF` = `github.ref_name` (unchanged); same-repo PR → `github.head_ref` (unchanged); fork PR → `refs/pull/<n>/head` from base repo (fixes the failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
