### PR TITLE
[Telemetry] Report Data Hub adoption via usage.* and datahub.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "nesbot/carbon": "^2.72 || ^3.8.4",
     "php": "~8.4.0 || ~8.5.0",
-    "pimcore/pimcore": "^2026.1",
+    "pimcore/pimcore": "^2026.3",
     "pimcore/studio-backend-bundle": "^2026.1",
     "pimcore/studio-ui-bundle": "^2026.1.6",
     "webonyx/graphql-php": "^15.2.3"

--- a/src/DependencyInjection/PimcoreDataHubExtension.php
+++ b/src/DependencyInjection/PimcoreDataHubExtension.php
@@ -41,6 +41,10 @@ final class PimcoreDataHubExtension extends Extension implements PrependExtensio
 
         $loader->load('config.yml');
         $loader->load('studio_backend.yaml');
+
+        // usage.* providers and the datahub.* collector; the core telemetry extension points
+        // are guaranteed by the pimcore/pimcore constraint in composer.json.
+        $loader->load('telemetry.yaml');
     }
 
     /**

--- a/src/DependencyInjection/PimcoreDataHubExtension.php
+++ b/src/DependencyInjection/PimcoreDataHubExtension.php
@@ -42,7 +42,7 @@ final class PimcoreDataHubExtension extends Extension implements PrependExtensio
         $loader->load('config.yml');
         $loader->load('studio_backend.yaml');
 
-        // usage.* providers and the datahub.* collector; the core telemetry extension points
+        // The usage.* provider and the datahub.* collector; the core telemetry extension points
         // are guaranteed by the pimcore/pimcore constraint in composer.json.
         $loader->load('telemetry.yaml');
     }

--- a/src/Resources/config/telemetry.yaml
+++ b/src/Resources/config/telemetry.yaml
@@ -1,6 +1,6 @@
-# Loaded only when the running Pimcore core ships the telemetry extension points - see
-# PimcoreDataHubExtension. The bundle supports ^2026.1, but those interfaces arrived later, so these
-# classes must never be autoloaded on a core that does not have them.
+# Telemetry integration: the usage.* provider, the datahub.* collector, and the shared
+# configuration read behind both. Loaded unconditionally by PimcoreDataHubExtension - the core
+# extension points are guaranteed by the pimcore/pimcore constraint in composer.json.
 services:
 
     _defaults:

--- a/src/Resources/config/telemetry.yaml
+++ b/src/Resources/config/telemetry.yaml
@@ -1,0 +1,18 @@
+# Loaded only when the running Pimcore core ships the telemetry extension points - see
+# PimcoreDataHubExtension. The bundle supports ^2026.1, but those interfaces arrived later, so these
+# classes must never be autoloaded on a core that does not have them.
+services:
+
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    # One read behind all five Data Hub packages; the satellites autowire this same instance.
+    Pimcore\Bundle\DataHubBundle\Telemetry\DataHubConfigurationUsage: ~
+
+    # usage.datahub_graphql (L3 - configured) - this bundle's own adapter only
+    Pimcore\Bundle\DataHubBundle\Telemetry\DataHubGraphQlUsageProvider: ~
+
+    # datahub.* (adapter mix, config counts)
+    Pimcore\Bundle\DataHubBundle\Telemetry\DataHubSnapshotCollector: ~

--- a/src/Telemetry/DataHubConfigurationUsage.php
+++ b/src/Telemetry/DataHubConfigurationUsage.php
@@ -1,0 +1,194 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Telemetry;
+
+use Pimcore\Bundle\DataHubBundle\Configuration;
+use Throwable;
+use function array_key_exists;
+use function in_array;
+use function is_string;
+
+/**
+ * The single read behind every Data Hub usage signal, for this bundle and for the four satellites.
+ *
+ * All five packages share ONE configuration store - Simple REST, webhooks, file export and Productsup
+ * are adapter *types* inside Data Hub's own configuration, not separate stores - so one pass over
+ * {@see Configuration::getList()} answers "is this adapter configured?" for the whole family. Each
+ * satellite asks this service for its own type rather than repeating the read.
+ *
+ * It goes through the bundle's configuration API on purpose, never a table. Data Hub configurations are
+ * location-aware: `pimcore_data_hub.config_location.data_hub` selects between the settings store and
+ * Symfony config files under `var/config/data_hub/`, and a third mode disables editing entirely. A
+ * probe that queried `plugin_datahub_config` directly would report "no configurations" for every
+ * customer on the file target - inventing an adoption gap rather than measuring one.
+ *
+ * Unresolvable is not the same as empty. When the read fails, every accessor returns null and the
+ * callers omit their keys, leaving the signal unknown.
+ *
+ * @internal
+ */
+final class DataHubConfigurationUsage
+{
+    /**
+     * Adapter types reported by name. Anything else is counted under {@see self::TYPE_OTHER}: a type is
+     * a free-text identifier that a customer or agency adapter can define, and third-party names are
+     * kept out of telemetry for the same reason `core.bundles` names only first-party bundles.
+     *
+     * The list is wider than the five Data Hub packages because the adapter registry is open and other
+     * first-party bundles plug into it - Data Importer and Headless Documents both register a type. That
+     * is a large part of the value here: the type mix shows which bundles integrate *through* Data Hub,
+     * which no bundle-active flag can express.
+     *
+     * @var list<string>
+     */
+    private const KNOWN_TYPES = [
+        'graphql',
+        'simpleRest',
+        'ciHub',
+        'webhooks',
+        'fileExport',
+        'productsup',
+        'dataImporterDataObject',
+        'headlessDocuments',
+    ];
+
+    private const TYPE_OTHER = 'other';
+
+    /**
+     * Every value {@see self::normalise()} can produce, so a caller can emit one property per type
+     * including the zeros rather than only the types this instance happens to use.
+     *
+     * @return list<string>
+     */
+    public static function reportableTypes(): array
+    {
+        return [...self::KNOWN_TYPES, self::TYPE_OTHER];
+    }
+
+    /**
+     * @var list<array{type: string, active: bool}>|null
+     */
+    private ?array $configurations = null;
+
+    private bool $loaded = false;
+
+    /**
+     * Active configurations per adapter type. Types with no active configuration are absent rather than
+     * zero, so the map stays small on instances using one adapter.
+     *
+     * @return array<string, int>|null null when the configuration store could not be read
+     */
+    public function activeCountsByType(): ?array
+    {
+        return $this->countsByType(true);
+    }
+
+    /**
+     * @return array<string, int>|null null when the configuration store could not be read
+     */
+    public function totalCountsByType(): ?array
+    {
+        return $this->countsByType(false);
+    }
+
+    /**
+     * Whether at least one configuration of any of the given types is active.
+     *
+     * @param list<string> $types
+     *
+     * @return bool|null null when the configuration store could not be read
+     */
+    public function hasActiveOfType(array $types): ?bool
+    {
+        $counts = $this->activeCountsByType();
+
+        if ($counts === null) {
+            return null;
+        }
+
+        foreach ($types as $type) {
+            if (array_key_exists($this->normalise($type), $counts)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, int>|null
+     */
+    private function countsByType(bool $activeOnly): ?array
+    {
+        $configurations = $this->load();
+
+        if ($configurations === null) {
+            return null;
+        }
+
+        $counts = [];
+        foreach ($configurations as $configuration) {
+            if ($activeOnly && !$configuration['active']) {
+                continue;
+            }
+
+            $type = $configuration['type'];
+            $counts[$type] = ($counts[$type] ?? 0) + 1;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Memoised: the snapshot asks up to five times (this bundle plus four satellites) within one run,
+     * and each call would otherwise re-read every configuration.
+     *
+     * @return list<array{type: string, active: bool}>|null
+     */
+    private function load(): ?array
+    {
+        if ($this->loaded) {
+            return $this->configurations;
+        }
+
+        $this->loaded = true;
+
+        try {
+            $configurations = [];
+
+            foreach (Configuration::getList() as $configuration) {
+                if (!$configuration instanceof Configuration) {
+                    continue;
+                }
+
+                $configurations[] = [
+                    'type' => $this->normalise($configuration->getType()),
+                    'active' => (bool) $configuration->isActive(),
+                ];
+            }
+
+            $this->configurations = $configurations;
+        } catch (Throwable) {
+            // Could not reach the configuration store - unknown, not empty.
+            $this->configurations = null;
+        }
+
+        return $this->configurations;
+    }
+
+    private function normalise(mixed $type): string
+    {
+        return is_string($type) && in_array($type, self::KNOWN_TYPES, true) ? $type : self::TYPE_OTHER;
+    }
+}

--- a/src/Telemetry/DataHubGraphQlUsageProvider.php
+++ b/src/Telemetry/DataHubGraphQlUsageProvider.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Telemetry;
+
+use Pimcore\Telemetry\Usage\BundleUsageProviderInterface;
+
+/**
+ * `usage.datahub_graphql` - this bundle's own adapter, the GraphQL endpoint, is used when at least one
+ * GraphQL configuration is **active**.
+ *
+ * Scoped to GraphQL rather than reporting the whole family, so that every package in the family answers
+ * the same question about itself and the five booleans are comparable. A family-wide roll-up would have
+ * gone true whenever any satellite had a configuration, which reads as "the GraphQL API is in use" and
+ * is not - `datahub.active_config_count` already carries the roll-up for anyone who wants it.
+ *
+ * Deliberately "active", not "exists": a disabled configuration is one somebody built and then turned
+ * off, which is the opposite of adoption. The flag self-resets when the last one is deactivated.
+ *
+ * This is the L3 (configured) signal. How much Data Hub is actually exercised is a different question
+ * with a different shape - counts per adapter, request volume - and lives in the `datahub.*` namespace
+ * via {@see DataHubSnapshotCollector} rather than being squeezed into this boolean.
+ *
+ * @internal
+ */
+final readonly class DataHubGraphQlUsageProvider implements BundleUsageProviderInterface
+{
+    public function __construct(
+        private DataHubConfigurationUsage $configurationUsage,
+    ) {
+    }
+
+    /**
+     * The adapter type this bundle itself ships.
+     *
+     * @var list<string>
+     */
+    private const ADAPTER_TYPES = ['graphql'];
+
+    public function getBundleKey(): string
+    {
+        return 'datahub_graphql';
+    }
+
+    public function isUsed(): ?bool
+    {
+        return $this->configurationUsage->hasActiveOfType(self::ADAPTER_TYPES);
+    }
+}

--- a/src/Telemetry/DataHubSnapshotCollector.php
+++ b/src/Telemetry/DataHubSnapshotCollector.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Telemetry;
+
+use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
+use function array_sum;
+use function preg_replace;
+use function strtolower;
+
+/**
+ * The `datahub.*` snapshot namespace: how Data Hub is set up, beyond the yes/no in `usage.datahub`.
+ *
+ * The interesting line is `config_count_by_type`. "Which integration style do customers actually use -
+ * GraphQL, REST, webhooks, scheduled file export?" cannot be answered from a bundle-active flag,
+ * because all of them ship inside the same family and one instance can run several at once. Counting
+ * active configurations per adapter type answers it with one structural read and no new events.
+ *
+ * Content-never: adapter types are Pimcore's own identifiers and are allow-listed by
+ * {@see DataHubConfigurationUsage} - configuration names, endpoints, API keys and workspace rules never
+ * leave. Counts are small structural integers, reported raw for the same reason
+ * `datamodel.class_count` is, not because they escaped the bucketing rule (that governs element
+ * volumes, which these are not).
+ *
+ * Emits nothing at all when the configuration store cannot be read, so an unreachable store never looks
+ * like an instance with zero configurations.
+ *
+ * @internal
+ */
+final readonly class DataHubSnapshotCollector implements SnapshotCollectorInterface
+{
+    public function __construct(
+        private DataHubConfigurationUsage $configurationUsage,
+    ) {
+    }
+
+    public function getNamespace(): string
+    {
+        return 'datahub';
+    }
+
+    public function collect(): array
+    {
+        $active = $this->configurationUsage->activeCountsByType();
+        $total = $this->configurationUsage->totalCountsByType();
+
+        if ($active === null || $total === null) {
+            return [];
+        }
+
+        return [
+            'schema_version' => 1,
+            'config_count' => array_sum($total),
+            'active_config_count' => array_sum($active),
+            // The Q5 answer: adapter type -> number of active configurations of that type.
+            'config_count_by_type' => $active,
+        ] + $this->flatCountsByType($active);
+    }
+
+    /**
+     * The same per-type numbers again, as one flat property each.
+     *
+     * The map above is the readable form, but analytics cannot chart it: PostHog only indexes scalar
+     * properties, so an object-valued property can be stored and read back yet never appears in a
+     * breakdown or aggregation - the adapter mix would be reachable only by writing SQL. A flat numeric
+     * property per type is chartable directly, which is the difference between a question the product
+     * team can answer themselves and one that needs an engineer.
+     *
+     * Every known type is emitted, including the zeros. An absent property is null rather than zero, and
+     * an average that silently skips the instances not using an adapter overstates that adapter's
+     * typical footprint.
+     *
+     * @param array<string, int> $active
+     *
+     * @return array<string, int>
+     */
+    private function flatCountsByType(array $active): array
+    {
+        $flat = [];
+
+        foreach (DataHubConfigurationUsage::reportableTypes() as $type) {
+            $flat['config_count_' . $this->propertySuffix($type)] = $active[$type] ?? 0;
+        }
+
+        return $flat;
+    }
+
+    /**
+     * `simpleRest` -> `simple_rest`, so the property names read like every other snapshot key.
+     */
+    private function propertySuffix(string $type): string
+    {
+        return strtolower((string) preg_replace('/([a-z0-9])([A-Z])/', '$1_$2', $type));
+    }
+}


### PR DESCRIPTION
Part of https://github.com/pimcore/product-management/issues/1414
## What

Adds `usage.datahub_graphql` (L3 — configured) and the `datahub.*` snapshot namespace: config counts and the per-adapter mix.

Requires `pimcore/pimcore: ^2026.3` for the telemetry extension points.

## Why the probe goes through the bundle's own API

Data Hub configurations are location-aware — `pimcore_data_hub.config_location.data_hub` selects between the settings store and Symfony config files under `var/config/data_hub/`. A probe reading `plugin_datahub_config` directly would report "no configurations" for every customer on the file target. On a real instance the split was roughly a third settings-store to two thirds files, so this is not theoretical.

## One read, five packages

Simple REST, webhooks, file export and Productsup are adapter **types** inside this bundle's configuration, not separate stores. `DataHubConfigurationUsage` is memoised and the satellites ask it for their own type.

`usage.datahub_graphql` is scoped to this bundle's own adapter so all five booleans answer the same question; `datahub.active_config_count` carries the family roll-up.

## Why the adapter mix is emitted twice

Once as a readable map, once as one flat numeric per type. Analytics only indexes scalar properties — an object-valued property can be stored and read back but never appears in a breakdown, so the mix would otherwise need SQL to reach. Zeros are included deliberately: an absent property is null, and an average that skips non-users overstates an adapter's footprint.

## Content-never

Adapter types are allow-listed; anything else counts as `other`, since a type is a free-text identifier a customer adapter can define. Configuration names, endpoints, API keys and workspace rules never leave. The allow-list is wider than this family because the registry is open — Data Importer and Headless Documents register types too, which is much of the value: it shows which bundles integrate *through* Data Hub.