### PR TITLE
Fork-PR checkouts: stop persisting the write token (follow-up to #1134)

### DIFF
--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
+          persist-credentials: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -49,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
+          persist-credentials: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -82,6 +84,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
+          persist-credentials: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -110,6 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
+          persist-credentials: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/shared-npm-publish.yaml
+++ b/.github/workflows/shared-npm-publish.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
+          persist-credentials: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -59,6 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
+          persist-credentials: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Cache npm dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Applies the mitigation Copilot's review flagged as High on #1134, which was merged with that item scoped out.

**Problem:** under `pull_request_target`, `actions/checkout` persists the `contents: write` `GITHUB_TOKEN` into `.git/config` by default. The lint/check-types/build jobs then run fork-controlled code (`npm ci` lifecycle hooks, npm scripts), which can read that credential and push to the base repo. Gating only the auto-commit step does not protect the token.

**Change (6 checkout sites across both shared workflows):**
```yaml
persist-credentials: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
```
Same-repo PRs and push/tag runs keep the token — the `git-auto-commit` steps keep working unchanged (this is the exact condition that already gates them). Fork-PR jobs become read-only: build/lint still run on the `refs/pull/<n>/head` checkout from #1134, but no credential is on disk.

**Deliberately not here:** the full restructure (read-only fork jobs + a separate trusted write-back job, as in the upstream reference) — that belongs to the `pull_request_target` security review in service-operations#1083, where these workflows are now in scope. This PR just removes the cheapest, highest-value part of the attack surface today.

After merge: forward-merge `2.4 → 2026.1` propagates this into 2026.1's copies of the same files (verified they exist there); the files don't exist above 2026.1, so the rest of the chain is ancestry-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)