### PR TITLE
fix(graphql): resolve QuantityValue unit to null when no unit is set

### DIFF
--- a/doc/01_Installation_and_Upgrade/01_Upgrade_Notes.md
+++ b/doc/01_Installation_and_Upgrade/01_Upgrade_Notes.md
@@ -5,6 +5,21 @@ description: Breaking changes and migration steps per release.
 
 # Upgrade Notes
 
+## Upgrade to 2026.2.6
+
+### GraphQL: `unit` of `QuantityValue` / `InputQuantityValue` is now `null` when no unit is set
+
+Quantity value fields without a selected unit previously returned the `unit` field as an object whose
+subfields were all `null` (e.g. `"unit": {"id": null}`). It is now `null` as the (nullable) schema
+definition implies:
+
+```json
+{ "length": { "value": 8500, "unit": null } }
+```
+
+Clients that access `unit` subfields unconditionally (e.g. `data.length.unit.id`) have to null-check
+`unit` first.
+
 ## Upgrade to 2026.1.0
 
 ### PHP & Symfony Version Requirements

--- a/src/GraphQL/Resolver/QuantityValue.php
+++ b/src/GraphQL/Resolver/QuantityValue.php
@@ -28,7 +28,7 @@ final class QuantityValue
      * @param array $args
      * @param array $context
      *
-     * @return array
+     * @return array|null
      *
      * @throws \Exception
      */
@@ -38,7 +38,7 @@ final class QuantityValue
             return $unit->getObjectVars();
         }
 
-        return [];
+        return null;
     }
 
     /**

--- a/tests/GraphQL/Resolver/QuantityValueTest.php
+++ b/tests/GraphQL/Resolver/QuantityValueTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataHubBundle\Tests\GraphQL\Resolver;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\DataHubBundle\GraphQL\Resolver\QuantityValue as QuantityValueResolver;
+use Pimcore\Model\DataObject\Data\InputQuantityValue;
+use Pimcore\Model\DataObject\Data\QuantityValue;
+use Pimcore\Model\DataObject\QuantityValue\Unit as QuantityValueUnit;
+
+class QuantityValueTest extends Unit
+{
+    private QuantityValueResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new QuantityValueResolver();
+    }
+
+    /**
+     * Without a unit the whole `unit` field has to resolve to null. Returning an empty array here made
+     * graphql-php's default field resolver resolve every requested subfield to null individually, so the
+     * response contained `unit: {id: null}` instead of `unit: null`.
+     */
+    public function testResolveUnitReturnsNullWhenNoUnitIsSet(): void
+    {
+        $this->assertNull($this->resolver->resolveUnit(new QuantityValue(8500)));
+    }
+
+    public function testResolveUnitReturnsNullWhenNoUnitIsSetOnInputQuantityValue(): void
+    {
+        $this->assertNull($this->resolver->resolveUnit(new InputQuantityValue('8500')));
+    }
+
+    public function testResolveUnitReturnsNullForNonQuantityValues(): void
+    {
+        $this->assertNull($this->resolver->resolveUnit(null));
+        $this->assertNull($this->resolver->resolveUnit('not a quantity value'));
+    }
+
+    public function testResolveUnitReturnsUnitVarsWhenUnitIsSet(): void
+    {
+        $unit = new QuantityValueUnit();
+        $unit->setId('mm');
+        $unit->setAbbreviation('mm');
+        $unit->setLongname('Millimeter');
+
+        $resolved = $this->resolver->resolveUnit(new QuantityValue(8500, $unit));
+
+        $this->assertIsArray($resolved);
+        $this->assertSame('mm', $resolved['id']);
+        $this->assertSame('mm', $resolved['abbreviation']);
+        $this->assertSame('Millimeter', $resolved['longname']);
+    }
+}


### PR DESCRIPTION
### Changes in this pull request

`QuantityValue::resolveUnit()` returned an empty array when a quantity value had no unit. Since `QuantityValueUnitType` defines no resolvers for its subfields (`id`, `abbreviation`, `longname`), graphql-php's `defaultFieldResolver` resolves each requested subfield of that array via `$array[$key] ?? null` — so an empty array made every subfield resolve to `null` individually instead of making the whole `unit` field `null`:

```json
{ "length": { "value": 8500, "unit": { "id": null } } }
```

Returning `null` instead makes `unit` itself `null`, which is what the (nullable) field definition in `QuantityValueType` implies:

```json
{ "length": { "value": 8500, "unit": null } }
```

This affects both `QuantityValue` and `InputQuantityValue` — `InputQuantityValueType extends QuantityValueType` and inherits the `unit` field and its resolver unchanged.

Also adds a regression test (`tests/GraphQL/Resolver/QuantityValueTest.php`) covering the no-unit case for both types, non-quantity-value input, and the unit-is-set case so the array shape stays intact.

### Heads-up for reviewers

This changes the response shape for consumers. A client accessing `unit` subfields unconditionally (e.g. `data.length.unit.id`) previously got `null` and now has to null-check `unit` first. I added an entry to `doc/01_Installation_and_Upgrade/01_Upgrade_Notes.md` — the version heading is a guess based on the latest tag (`v2026.2.5`), please adjust it if this lands in a different release.

### Additional info

Verified locally (PHP 8.4): the new tests fail against the current code with `Failed asserting that Array &0 [] is null` (3 of 4) and pass with the fix; PHPStan and php-cs-fixer are clean on the changed files.

Fixes pimcore/platform-version#324