### PR TITLE
Remove committed build output from pull_request trigger paths

### DIFF
--- a/.github/workflows/studio-frontend-build.yaml
+++ b/.github/workflows/studio-frontend-build.yaml
@@ -8,7 +8,6 @@ on:
   pull_request:
     paths:
       - "assets/studio/**"
-      - "src/Resources/public/studio/build/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Removes the committed build output directory from the pull_request paths of the Studio Frontend Build workflow. Push paths stay unchanged (stale-output detection kept).

pull_request path filters match the whole PR diff, not the last commit — once the workflow commits build output into a PR, every later push re-triggers a frontend build, even pushes touching unrelated files. Same fix as rolled out to the other studio bundles; org-wide sweep found this repo still carrying the line.